### PR TITLE
Surface reconstruction from points (#112)

### DIFF
--- a/include/jet/anisotropic_points_to_implicit2.h
+++ b/include/jet/anisotropic_points_to_implicit2.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef INCLUDE_JET_ANISOTROPIC_POINTS_TO_IMPLICIT2_H_
+#define INCLUDE_JET_ANISOTROPIC_POINTS_TO_IMPLICIT2_H_
+
+#include <jet/points_to_implicit2.h>
+
+namespace jet {
+
+//!
+//! \brief 2-D points-to-implicit converter using Anisotropic kernels.
+//!
+//! This class converts 2-D points to implicit surface using anisotropic kernels
+//! so that the kernels are oriented and stretched to reflect the point
+//! distribution more naturally (thus less bumps). The implementation is based
+//! on Yu and Turk's 2013 paper with some modifications.
+//!
+//! \see Yu, Jihun, and Greg Turk. "Reconstructing surfaces of particle-based
+//!      fluids using anisotropic kernels." ACM Transactions on Graphics (TOG)
+//!      32.1 (2013): 5.
+//!
+class AnisotropicPointsToImplicit2 final : public PointsToImplicit2 {
+ public:
+    //!
+    //! \brief Constructs the converter with given parameters.
+    //!
+    //! \param kernelRadius Kernel radius for interpolations.
+    //! \param cutOffDensity Iso-contour density value.
+    //! \param positionSmoothingFactor Position smoothing factor.
+    //! \param minNumNeighbors Minimum number of neighbors to enable anisotropic
+    //!                        kernel.
+    //!
+    AnisotropicPointsToImplicit2(double kernelRadius = 1.0,
+                                 double cutOffDensity = 0.5,
+                                 double positionSmoothingFactor = 0.0,
+                                 size_t minNumNeighbors = 8);
+
+    //! Converts the given points to implicit surface scalar field.
+    void convert(const ConstArrayAccessor1<Vector2D>& points,
+                 ScalarGrid2* output) const override;
+
+ private:
+    double _kernelRadius = 1.0;
+    double _cutOffDensity = 0.5;
+    double _positionSmoothingFactor = 0.0;
+    size_t _minNumNeighbors = 8;
+};
+
+//! Shared pointer for the AnisotropicPointsToImplicit2 type.
+typedef std::shared_ptr<AnisotropicPointsToImplicit2>
+    AnisotropicPointsToImplicit2Ptr;
+
+}  // namespace jet
+
+#endif  // INCLUDE_JET_ANISOTROPIC_POINTS_TO_IMPLICIT2_H_

--- a/include/jet/anisotropic_points_to_implicit3.h
+++ b/include/jet/anisotropic_points_to_implicit3.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef INCLUDE_JET_ANISOTROPIC_POINTS_TO_IMPLICIT3_H_
+#define INCLUDE_JET_ANISOTROPIC_POINTS_TO_IMPLICIT3_H_
+
+#include <jet/points_to_implicit3.h>
+
+namespace jet {
+
+//!
+//! \brief 3-D points-to-implicit converter using Anisotropic kernels.
+//!
+//! This class converts 3-D points to implicit surface using anisotropic kernels
+//! so that the kernels are oriented and stretched to reflect the point
+//! distribution more naturally (thus less bumps). The implementation is based
+//! on Yu and Turk's 2013 paper with some modifications.
+//!
+//! \see Yu, Jihun, and Greg Turk. "Reconstructing surfaces of particle-based
+//!      fluids using anisotropic kernels." ACM Transactions on Graphics (TOG)
+//!      32.1 (2013): 5.
+//!
+class AnisotropicPointsToImplicit3 final : public PointsToImplicit3 {
+ public:
+    //!
+    //! \brief Constructs the converter with given parameters.
+    //!
+    //! \param kernelRadius Kernel radius for interpolations.
+    //! \param cutOffDensity Iso-contour density value.
+    //! \param positionSmoothingFactor Position smoothing factor.
+    //! \param minNumNeighbors Minimum number of neighbors to enable anisotropic
+    //!                        kernel.
+    //!
+    AnisotropicPointsToImplicit3(double kernelRadius = 1.0,
+                                 double cutOffDensity = 0.5,
+                                 double positionSmoothingFactor = 0.0,
+                                 size_t minNumNeighbors = 25);
+
+    //! Converts the given points to implicit surface scalar field.
+    void convert(const ConstArrayAccessor1<Vector3D>& points,
+                 ScalarGrid3* output) const override;
+
+ private:
+    double _kernelRadius = 1.0;
+    double _cutOffDensity = 0.5;
+    double _positionSmoothingFactor = 0.0;
+    size_t _minNumNeighbors = 25;
+};
+
+//! Shared pointer for the AnisotropicPointsToImplicit3 type.
+typedef std::shared_ptr<AnisotropicPointsToImplicit3>
+    AnisotropicPointsToImplicit3Ptr;
+
+}  // namespace jet
+
+#endif  // INCLUDE_JET_ANISOTROPIC_POINTS_TO_IMPLICIT3_H_

--- a/include/jet/bounding_box2.h
+++ b/include/jet/bounding_box2.h
@@ -108,6 +108,9 @@ class BoundingBox<T, 2> {
 
     //! Returns the clamped point.
     Vector2<T> clamp(const Vector2<T>& pt) const;
+
+    //! Returns true if the box is empty.
+    bool isEmpty() const;
 };
 
 //! Type alias for 2-D BoundingBox.

--- a/include/jet/bounding_box3.h
+++ b/include/jet/bounding_box3.h
@@ -111,6 +111,9 @@ class BoundingBox<T, 3> {
 
     //! Returns the clamped point.
     Vector3<T> clamp(const Vector3<T>& point) const;
+
+    //! Returns true if the box is empty.
+    bool isEmpty() const;
 };
 
 //! Type alias for 3-D BoundingBox.

--- a/include/jet/detail/bounding_box2-inl.h
+++ b/include/jet/detail/bounding_box2-inl.h
@@ -199,6 +199,11 @@ Vector2<T> BoundingBox<T, 2>::clamp(const Vector2<T>& pt) const {
     return ::jet::clamp(pt, lowerCorner, upperCorner);
 }
 
+template <typename T>
+bool BoundingBox<T, 2>::isEmpty() const {
+    return (lowerCorner.x >= upperCorner.x || lowerCorner.y >= upperCorner.y);
+}
+
 }  // namespace jet
 
 #endif  // INCLUDE_JET_DETAIL_BOUNDING_BOX2_INL_H_

--- a/include/jet/detail/bounding_box3-inl.h
+++ b/include/jet/detail/bounding_box3-inl.h
@@ -212,6 +212,12 @@ Vector3<T> BoundingBox<T, 3>::clamp(const Vector3<T>& pt) const {
     return ::jet::clamp(pt, lowerCorner, upperCorner);
 }
 
+template <typename T>
+bool BoundingBox<T, 3>::isEmpty() const {
+    return (lowerCorner.x >= upperCorner.x || lowerCorner.y >= upperCorner.y ||
+            lowerCorner.z >= upperCorner.z);
+}
+
 }  // namespace jet
 
 #endif  // INCLUDE_JET_DETAIL_BOUNDING_BOX3_INL_H_

--- a/include/jet/detail/matrix2x2-inl.h
+++ b/include/jet/detail/matrix2x2-inl.h
@@ -17,8 +17,7 @@ namespace jet {
 // MARK: CTOR/DTOR
 template <typename T>
 Matrix<T, 2, 2>::Matrix() {
-    set(1, 0,
-        0, 1);
+    set(1, 0, 0, 1);
 }
 
 template <typename T>
@@ -27,9 +26,7 @@ Matrix<T, 2, 2>::Matrix(T s) {
 }
 
 template <typename T>
-Matrix<T, 2, 2>::Matrix(
-    T m00, T m01,
-    T m10, T m11) {
+Matrix<T, 2, 2>::Matrix(T m00, T m01, T m10, T m11) {
     set(m00, m01, m10, m11);
 }
 
@@ -50,7 +47,6 @@ Matrix<T, 2, 2>::Matrix(const T* arr) {
     set(arr);
 }
 
-
 // MARK: Basic setters
 template <typename T>
 void Matrix<T, 2, 2>::set(T s) {
@@ -58,9 +54,7 @@ void Matrix<T, 2, 2>::set(T s) {
 }
 
 template <typename T>
-void Matrix<T, 2, 2>::set(
-    T m00, T m01,
-    T m10, T m11) {
+void Matrix<T, 2, 2>::set(T m00, T m01, T m10, T m11) {
     _elements[0] = m00;
     _elements[1] = m01;
     _elements[2] = m10;
@@ -120,14 +114,13 @@ void Matrix<T, 2, 2>::setColumn(size_t j, const Vector<T, 2>& col) {
     _elements[j + 2] = col.y;
 }
 
-
 // MARK: Basic getters
 template <typename T>
 bool Matrix<T, 2, 2>::isSimilar(const Matrix& m, double tol) const {
-    return (std::fabs(_elements[0] - m._elements[0]) < tol)
-        && (std::fabs(_elements[1] - m._elements[1]) < tol)
-        && (std::fabs(_elements[2] - m._elements[2]) < tol)
-        && (std::fabs(_elements[3] - m._elements[3]) < tol);
+    return (std::fabs(_elements[0] - m._elements[0]) < tol) &&
+           (std::fabs(_elements[1] - m._elements[1]) < tol) &&
+           (std::fabs(_elements[2] - m._elements[2]) < tol) &&
+           (std::fabs(_elements[3] - m._elements[3]) < tol);
 }
 
 template <typename T>
@@ -155,51 +148,35 @@ const T* Matrix<T, 2, 2>::data() const {
     return _elements.data();
 }
 
-
 // MARK: Binary operator methods - new instance = this instance (+) input
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::add(T s) const {
-    return Matrix(
-        _elements[0] + s,
-        _elements[1] + s,
-        _elements[2] + s,
-        _elements[3] + s);
+    return Matrix(_elements[0] + s, _elements[1] + s, _elements[2] + s,
+                  _elements[3] + s);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::add(const Matrix& m) const {
-    return Matrix(
-        _elements[0] + m._elements[0],
-        _elements[1] + m._elements[1],
-        _elements[2] + m._elements[2],
-        _elements[3] + m._elements[3]);
+    return Matrix(_elements[0] + m._elements[0], _elements[1] + m._elements[1],
+                  _elements[2] + m._elements[2], _elements[3] + m._elements[3]);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::sub(T s) const {
-    return Matrix(
-        _elements[0] - s,
-        _elements[1] - s,
-        _elements[2] - s,
-        _elements[3] - s);
+    return Matrix(_elements[0] - s, _elements[1] - s, _elements[2] - s,
+                  _elements[3] - s);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::sub(const Matrix& m) const {
-    return Matrix(
-        _elements[0] - m._elements[0],
-        _elements[1] - m._elements[1],
-        _elements[2] - m._elements[2],
-        _elements[3] - m._elements[3]);
+    return Matrix(_elements[0] - m._elements[0], _elements[1] - m._elements[1],
+                  _elements[2] - m._elements[2], _elements[3] - m._elements[3]);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::mul(T s) const {
-    return Matrix(
-        _elements[0] * s,
-        _elements[1] * s,
-        _elements[2] * s,
-        _elements[3] * s);
+    return Matrix(_elements[0] * s, _elements[1] * s, _elements[2] * s,
+                  _elements[3] * s);
 }
 
 template <typename T>
@@ -219,55 +196,39 @@ Matrix<T, 2, 2> Matrix<T, 2, 2>::mul(const Matrix& m) const {
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::div(T s) const {
-    return Matrix(
-        _elements[0] / s,
-        _elements[1] / s,
-        _elements[2] / s,
-        _elements[3] / s);
+    return Matrix(_elements[0] / s, _elements[1] / s, _elements[2] / s,
+                  _elements[3] / s);
 }
-
 
 // MARK: Binary operator methods - new instance = input (+) this instance
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::radd(T s) const {
-    return Matrix(
-        s + _elements[0],
-        s + _elements[1],
-        s + _elements[2],
-        s + _elements[3]);
+    return Matrix(s + _elements[0], s + _elements[1], s + _elements[2],
+                  s + _elements[3]);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::radd(const Matrix& m) const {
-    return Matrix(
-        m._elements[0] + _elements[0],
-        m._elements[1] + _elements[1],
-        m._elements[2] + _elements[2],
-        m._elements[3] + _elements[3]);
+    return Matrix(m._elements[0] + _elements[0], m._elements[1] + _elements[1],
+                  m._elements[2] + _elements[2], m._elements[3] + _elements[3]);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::rsub(T s) const {
-    return Matrix(
-        s - _elements[0],
-        s - _elements[1],
-        s - _elements[2],
-        s - _elements[3]);
+    return Matrix(s - _elements[0], s - _elements[1], s - _elements[2],
+                  s - _elements[3]);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::rsub(const Matrix& m) const {
-    return Matrix(
-        m._elements[0] - _elements[0],
-        m._elements[1] - _elements[1],
-        m._elements[2] - _elements[2],
-        m._elements[3] - _elements[3]);
+    return Matrix(m._elements[0] - _elements[0], m._elements[1] - _elements[1],
+                  m._elements[2] - _elements[2], m._elements[3] - _elements[3]);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::rmul(T s) const {
-    return Matrix(
-        s*_elements[0], s*_elements[1], s*_elements[2], s*_elements[3]);
+    return Matrix(s * _elements[0], s * _elements[1], s * _elements[2],
+                  s * _elements[3]);
 }
 
 template <typename T>
@@ -277,11 +238,8 @@ Matrix<T, 2, 2> Matrix<T, 2, 2>::rmul(const Matrix& m) const {
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::rdiv(T s) const {
-    return Matrix(
-        s / _elements[0],
-        s / _elements[1],
-        s / _elements[2],
-        s / _elements[3]);
+    return Matrix(s / _elements[0], s / _elements[1], s / _elements[2],
+                  s / _elements[3]);
 }
 
 // MARK: Augmented operator methods - this instance (+)= input
@@ -338,7 +296,6 @@ void Matrix<T, 2, 2>::idiv(T s) {
     _elements[3] /= s;
 }
 
-
 // MARK: Modifiers
 template <typename T>
 void Matrix<T, 2, 2>::transpose() {
@@ -358,7 +315,6 @@ void Matrix<T, 2, 2>::invert() {
     set(m);
 }
 
-
 // MARK: Complex getters
 template <typename T>
 T Matrix<T, 2, 2>::sum() const {
@@ -376,30 +332,26 @@ T Matrix<T, 2, 2>::avg() const {
 
 template <typename T>
 T Matrix<T, 2, 2>::min() const {
-    return std::min(
-        std::min(_elements[0], _elements[1]),
-        std::min(_elements[2], _elements[3]));
+    return std::min(std::min(_elements[0], _elements[1]),
+                    std::min(_elements[2], _elements[3]));
 }
 
 template <typename T>
 T Matrix<T, 2, 2>::max() const {
-    return std::max(
-        std::max(_elements[0], _elements[1]),
-        std::max(_elements[2], _elements[3]));
+    return std::max(std::max(_elements[0], _elements[1]),
+                    std::max(_elements[2], _elements[3]));
 }
 
 template <typename T>
 T Matrix<T, 2, 2>::absmin() const {
-    return ::jet::absmin(
-        ::jet::absmin(_elements[0], _elements[1]),
-        ::jet::absmin(_elements[2], _elements[3]));
+    return ::jet::absmin(::jet::absmin(_elements[0], _elements[1]),
+                         ::jet::absmin(_elements[2], _elements[3]));
 }
 
 template <typename T>
 T Matrix<T, 2, 2>::absmax() const {
-    return ::jet::absmax(
-        ::jet::absmax(_elements[0], _elements[1]),
-        ::jet::absmax(_elements[2], _elements[3]));
+    return ::jet::absmax(::jet::absmax(_elements[0], _elements[1]),
+                         ::jet::absmax(_elements[2], _elements[3]));
 }
 
 template <typename T>
@@ -414,51 +366,37 @@ T Matrix<T, 2, 2>::determinant() const {
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::diagonal() const {
-    return Matrix(
-        _elements[0], 0,
-        0, _elements[3]);
+    return Matrix(_elements[0], 0, 0, _elements[3]);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::offDiagonal() const {
-    return Matrix(
-        0, _elements[1],
-        _elements[2], 0);
+    return Matrix(0, _elements[1], _elements[2], 0);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::strictLowerTri() const {
-    return Matrix(
-        0, 0,
-        _elements[2], 0);
+    return Matrix(0, 0, _elements[2], 0);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::strictUpperTri() const {
-    return Matrix(
-        0, _elements[1],
-        0, 0);
+    return Matrix(0, _elements[1], 0, 0);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::lowerTri() const {
-    return Matrix(
-        _elements[0], 0,
-        _elements[2], _elements[3]);
+    return Matrix(_elements[0], 0, _elements[2], _elements[3]);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::upperTri() const {
-    return Matrix(
-        _elements[0], _elements[1],
-        0, _elements[3]);
+    return Matrix(_elements[0], _elements[1], 0, _elements[3]);
 }
 
 template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::transposed() const {
-    return Matrix(
-        _elements[0], _elements[2],
-        _elements[1], _elements[3]);
+    return Matrix(_elements[0], _elements[2], _elements[1], _elements[3]);
 }
 
 template <typename T>
@@ -469,15 +407,18 @@ Matrix<T, 2, 2> Matrix<T, 2, 2>::inverse() const {
 }
 
 template <typename T>
+T Matrix<T, 2, 2>::frobeniusNorm() const {
+    return std::sqrt(_elements[0] * _elements[0] + _elements[1] * _elements[1] +
+                     _elements[2] * _elements[2] + _elements[3] * _elements[3]);
+}
+
+template <typename T>
 template <typename U>
 Matrix<U, 2, 2> Matrix<T, 2, 2>::castTo() const {
     return Matrix<U, 2, 2>(
-        static_cast<U>(_elements[0]),
-        static_cast<U>(_elements[1]),
-        static_cast<U>(_elements[2]),
-        static_cast<U>(_elements[3]));
+        static_cast<U>(_elements[0]), static_cast<U>(_elements[1]),
+        static_cast<U>(_elements[2]), static_cast<U>(_elements[3]));
 }
-
 
 // MARK: Setter operators
 template <typename T>
@@ -540,7 +481,6 @@ bool Matrix<T, 2, 2>::operator!=(const Matrix& m) const {
            _elements[2] != m._elements[2] || _elements[3] != m._elements[3];
 }
 
-
 // MARK: Getter operators
 template <typename T>
 T& Matrix<T, 2, 2>::operator[](size_t i) {
@@ -561,7 +501,6 @@ template <typename T>
 const T& Matrix<T, 2, 2>::operator()(size_t i, size_t j) const {
     return _elements[2 * i + j];
 }
-
 
 // MARK: Helpers
 template <typename T>
@@ -588,7 +527,6 @@ template <typename T>
 Matrix<T, 2, 2> Matrix<T, 2, 2>::makeRotationMatrix(const T& rad) {
     return Matrix(std::cos(rad), -std::sin(rad), std::sin(rad), std::cos(rad));
 }
-
 
 // MARK: Operator overloadings
 template <typename T>

--- a/include/jet/detail/matrix3x3-inl.h
+++ b/include/jet/detail/matrix3x3-inl.h
@@ -17,9 +17,7 @@ namespace jet {
 // MARK: CTOR/DTOR
 template <typename T>
 Matrix<T, 3, 3>::Matrix() {
-    set(1, 0, 0,
-        0, 1, 0,
-        0, 0, 1);
+    set(1, 0, 0, 0, 1, 0, 0, 0, 1);
 }
 
 template <typename T>
@@ -28,13 +26,9 @@ Matrix<T, 3, 3>::Matrix(T s) {
 }
 
 template <typename T>
-Matrix<T, 3, 3>::Matrix(
-    T m00, T m01, T m02,
-    T m10, T m11, T m12,
-    T m20, T m21, T m22) {
-    set(m00, m01, m02,
-        m10, m11, m12,
-        m20, m21, m22);
+Matrix<T, 3, 3>::Matrix(T m00, T m01, T m02, T m10, T m11, T m12, T m20, T m21,
+                        T m22) {
+    set(m00, m01, m02, m10, m11, m12, m20, m21, m22);
 }
 
 template <typename T>
@@ -54,20 +48,16 @@ Matrix<T, 3, 3>::Matrix(const T* arr) {
     set(arr);
 }
 
-
 // MARK: Basic setters
 template <typename T>
 void Matrix<T, 3, 3>::set(T s) {
-    _elements[0] = _elements[3] = _elements[6] =
-    _elements[1] = _elements[4] = _elements[7] =
-    _elements[2] = _elements[5] = _elements[8] = s;
+    _elements[0] = _elements[3] = _elements[6] = _elements[1] = _elements[4] =
+        _elements[7] = _elements[2] = _elements[5] = _elements[8] = s;
 }
 
 template <typename T>
-void Matrix<T, 3, 3>::set(
-    T m00, T m01, T m02,
-    T m10, T m11, T m12,
-    T m20, T m21, T m22) {
+void Matrix<T, 3, 3>::set(T m00, T m01, T m02, T m10, T m11, T m12, T m20,
+                          T m21, T m22) {
     _elements[0] = m00;
     _elements[1] = m01;
     _elements[2] = m02;
@@ -117,8 +107,8 @@ void Matrix<T, 3, 3>::setDiagonal(T s) {
 
 template <typename T>
 void Matrix<T, 3, 3>::setOffDiagonal(T s) {
-    _elements[1] = _elements[2] = _elements[3]
-    = _elements[5] = _elements[6] = _elements[7] = s;
+    _elements[1] = _elements[2] = _elements[3] = _elements[5] = _elements[6] =
+        _elements[7] = s;
 }
 
 template <typename T>
@@ -135,20 +125,18 @@ void Matrix<T, 3, 3>::setColumn(size_t j, const Vector<T, 3>& col) {
     _elements[j + 6] = col.z;
 }
 
-
 // MARK: Basic getters
 template <typename T>
 bool Matrix<T, 3, 3>::isSimilar(const Matrix& m, double tol) const {
-    return
-        std::fabs(_elements[0] - m._elements[0]) < tol
-     && std::fabs(_elements[1] - m._elements[1]) < tol
-     && std::fabs(_elements[2] - m._elements[2]) < tol
-     && std::fabs(_elements[3] - m._elements[3]) < tol
-     && std::fabs(_elements[4] - m._elements[4]) < tol
-     && std::fabs(_elements[5] - m._elements[5]) < tol
-     && std::fabs(_elements[6] - m._elements[6]) < tol
-     && std::fabs(_elements[7] - m._elements[7]) < tol
-     && std::fabs(_elements[8] - m._elements[8]) < tol;
+    return std::fabs(_elements[0] - m._elements[0]) < tol &&
+           std::fabs(_elements[1] - m._elements[1]) < tol &&
+           std::fabs(_elements[2] - m._elements[2]) < tol &&
+           std::fabs(_elements[3] - m._elements[3]) < tol &&
+           std::fabs(_elements[4] - m._elements[4]) < tol &&
+           std::fabs(_elements[5] - m._elements[5]) < tol &&
+           std::fabs(_elements[6] - m._elements[6]) < tol &&
+           std::fabs(_elements[7] - m._elements[7]) < tol &&
+           std::fabs(_elements[8] - m._elements[8]) < tol;
 }
 
 template <typename T>
@@ -176,58 +164,44 @@ const T* Matrix<T, 3, 3>::data() const {
     return _elements.data();
 }
 
-
 // MARK: Binary operator methods - new instance = this instance (+) input
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::add(T s) const {
-    return Matrix(
-        _elements[0] + s, _elements[1] + s, _elements[2] + s,
-        _elements[3] + s, _elements[4] + s, _elements[5] + s,
-        _elements[6] + s, _elements[7] + s, _elements[8] + s);
+    return Matrix(_elements[0] + s, _elements[1] + s, _elements[2] + s,
+                  _elements[3] + s, _elements[4] + s, _elements[5] + s,
+                  _elements[6] + s, _elements[7] + s, _elements[8] + s);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::add(const Matrix& m) const {
-    return Matrix(
-        _elements[0] + m._elements[0],
-        _elements[1] + m._elements[1],
-        _elements[2] + m._elements[2],
-        _elements[3] + m._elements[3],
-        _elements[4] + m._elements[4],
-        _elements[5] + m._elements[5],
-        _elements[6] + m._elements[6],
-        _elements[7] + m._elements[7],
-        _elements[8] + m._elements[8]);
+    return Matrix(_elements[0] + m._elements[0], _elements[1] + m._elements[1],
+                  _elements[2] + m._elements[2], _elements[3] + m._elements[3],
+                  _elements[4] + m._elements[4], _elements[5] + m._elements[5],
+                  _elements[6] + m._elements[6], _elements[7] + m._elements[7],
+                  _elements[8] + m._elements[8]);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::sub(T s) const {
-    return Matrix(
-        _elements[0] - s, _elements[1] - s, _elements[2] - s,
-        _elements[3] - s, _elements[4] - s, _elements[5] - s,
-        _elements[6] - s, _elements[7] - s, _elements[8] - s);
+    return Matrix(_elements[0] - s, _elements[1] - s, _elements[2] - s,
+                  _elements[3] - s, _elements[4] - s, _elements[5] - s,
+                  _elements[6] - s, _elements[7] - s, _elements[8] - s);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::sub(const Matrix& m) const {
-    return Matrix(
-        _elements[0] - m._elements[0],
-        _elements[1] - m._elements[1],
-        _elements[2] - m._elements[2],
-        _elements[3] - m._elements[3],
-        _elements[4] - m._elements[4],
-        _elements[5] - m._elements[5],
-        _elements[6] - m._elements[6],
-        _elements[7] - m._elements[7],
-        _elements[8] - m._elements[8]);
+    return Matrix(_elements[0] - m._elements[0], _elements[1] - m._elements[1],
+                  _elements[2] - m._elements[2], _elements[3] - m._elements[3],
+                  _elements[4] - m._elements[4], _elements[5] - m._elements[5],
+                  _elements[6] - m._elements[6], _elements[7] - m._elements[7],
+                  _elements[8] - m._elements[8]);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::mul(T s) const {
-    return Matrix(
-        _elements[0] * s, _elements[1] * s, _elements[2] * s,
-        _elements[3] * s, _elements[4] * s, _elements[5] * s,
-        _elements[6] * s, _elements[7] * s, _elements[8] * s);
+    return Matrix(_elements[0] * s, _elements[1] * s, _elements[2] * s,
+                  _elements[3] * s, _elements[4] * s, _elements[5] * s,
+                  _elements[6] * s, _elements[7] * s, _elements[8] * s);
 }
 
 template <typename T>
@@ -241,97 +215,73 @@ Vector<T, 3> Matrix<T, 3, 3>::mul(const Vector<T, 3>& v) const {
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::mul(const Matrix& m) const {
     return Matrix(
-        _elements[0] * m._elements[0]
-      + _elements[1] * m._elements[3]
-      + _elements[2] * m._elements[6],
-        _elements[0] * m._elements[1]
-      + _elements[1] * m._elements[4]
-      + _elements[2] * m._elements[7],
-        _elements[0] * m._elements[2]
-      + _elements[1] * m._elements[5]
-      + _elements[2] * m._elements[8],
+        _elements[0] * m._elements[0] + _elements[1] * m._elements[3] +
+            _elements[2] * m._elements[6],
+        _elements[0] * m._elements[1] + _elements[1] * m._elements[4] +
+            _elements[2] * m._elements[7],
+        _elements[0] * m._elements[2] + _elements[1] * m._elements[5] +
+            _elements[2] * m._elements[8],
 
-        _elements[3] * m._elements[0]
-      + _elements[4] * m._elements[3]
-      + _elements[5] * m._elements[6],
-        _elements[3] * m._elements[1]
-      + _elements[4] * m._elements[4]
-      + _elements[5] * m._elements[7],
-        _elements[3] * m._elements[2]
-      + _elements[4] * m._elements[5]
-      + _elements[5] * m._elements[8],
+        _elements[3] * m._elements[0] + _elements[4] * m._elements[3] +
+            _elements[5] * m._elements[6],
+        _elements[3] * m._elements[1] + _elements[4] * m._elements[4] +
+            _elements[5] * m._elements[7],
+        _elements[3] * m._elements[2] + _elements[4] * m._elements[5] +
+            _elements[5] * m._elements[8],
 
-        _elements[6] * m._elements[0]
-      + _elements[7] * m._elements[3]
-      + _elements[8] * m._elements[6],
-        _elements[6] * m._elements[1]
-      + _elements[7] * m._elements[4]
-      + _elements[8] * m._elements[7],
-        _elements[6] * m._elements[2]
-      + _elements[7] * m._elements[5]
-      + _elements[8] * m._elements[8]);
+        _elements[6] * m._elements[0] + _elements[7] * m._elements[3] +
+            _elements[8] * m._elements[6],
+        _elements[6] * m._elements[1] + _elements[7] * m._elements[4] +
+            _elements[8] * m._elements[7],
+        _elements[6] * m._elements[2] + _elements[7] * m._elements[5] +
+            _elements[8] * m._elements[8]);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::div(T s) const {
-    return Matrix(
-        _elements[0] / s, _elements[1] / s, _elements[2] / s,
-        _elements[3] / s, _elements[4] / s, _elements[5] / s,
-        _elements[6] / s, _elements[7] / s, _elements[8] / s);
+    return Matrix(_elements[0] / s, _elements[1] / s, _elements[2] / s,
+                  _elements[3] / s, _elements[4] / s, _elements[5] / s,
+                  _elements[6] / s, _elements[7] / s, _elements[8] / s);
 }
-
 
 // MARK: Binary operator methods - new instance = input (+) this instance
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::radd(T s) const {
-    return Matrix(
-        s + _elements[0], s + _elements[1], s + _elements[2],
-        s + _elements[3], s + _elements[4], s + _elements[5],
-        s + _elements[6], s + _elements[7], s + _elements[8]);
+    return Matrix(s + _elements[0], s + _elements[1], s + _elements[2],
+                  s + _elements[3], s + _elements[4], s + _elements[5],
+                  s + _elements[6], s + _elements[7], s + _elements[8]);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::radd(const Matrix& m) const {
-    return Matrix(
-        m._elements[0] + _elements[0],
-        m._elements[1] + _elements[1],
-        m._elements[2] + _elements[2],
-        m._elements[3] + _elements[3],
-        m._elements[4] + _elements[4],
-        m._elements[5] + _elements[5],
-        m._elements[6] + _elements[6],
-        m._elements[7] + _elements[7],
-        m._elements[8] + _elements[8]);
+    return Matrix(m._elements[0] + _elements[0], m._elements[1] + _elements[1],
+                  m._elements[2] + _elements[2], m._elements[3] + _elements[3],
+                  m._elements[4] + _elements[4], m._elements[5] + _elements[5],
+                  m._elements[6] + _elements[6], m._elements[7] + _elements[7],
+                  m._elements[8] + _elements[8]);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::rsub(T s) const {
-    return Matrix(
-        s - _elements[0], s - _elements[1], s - _elements[2],
-        s - _elements[3], s - _elements[4], s - _elements[5],
-        s - _elements[6], s - _elements[7], s - _elements[8]);
+    return Matrix(s - _elements[0], s - _elements[1], s - _elements[2],
+                  s - _elements[3], s - _elements[4], s - _elements[5],
+                  s - _elements[6], s - _elements[7], s - _elements[8]);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::rsub(const Matrix& m) const {
-    return Matrix(
-        m._elements[0] - _elements[0],
-        m._elements[1] - _elements[1],
-        m._elements[2] - _elements[2],
-        m._elements[3] - _elements[3],
-        m._elements[4] - _elements[4],
-        m._elements[5] - _elements[5],
-        m._elements[6] - _elements[6],
-        m._elements[7] - _elements[7],
-        m._elements[8] - _elements[8]);
+    return Matrix(m._elements[0] - _elements[0], m._elements[1] - _elements[1],
+                  m._elements[2] - _elements[2], m._elements[3] - _elements[3],
+                  m._elements[4] - _elements[4], m._elements[5] - _elements[5],
+                  m._elements[6] - _elements[6], m._elements[7] - _elements[7],
+                  m._elements[8] - _elements[8]);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::rmul(T s) const {
-    return Matrix(
-        s * _elements[0], s * _elements[1], s * _elements[2],
-        s * _elements[3], s * _elements[4], s * _elements[5],
-        s * _elements[6], s * _elements[7], s * _elements[8]);
+    return Matrix(s * _elements[0], s * _elements[1], s * _elements[2],
+                  s * _elements[3], s * _elements[4], s * _elements[5],
+                  s * _elements[6], s * _elements[7], s * _elements[8]);
 }
 
 template <typename T>
@@ -341,10 +291,9 @@ Matrix<T, 3, 3> Matrix<T, 3, 3>::rmul(const Matrix& m) const {
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::rdiv(T s) const {
-    return Matrix(
-        s / _elements[0], s / _elements[1], s / _elements[2],
-        s / _elements[3], s / _elements[4], s / _elements[5],
-        s / _elements[6], s / _elements[7], s / _elements[8]);
+    return Matrix(s / _elements[0], s / _elements[1], s / _elements[2],
+                  s / _elements[3], s / _elements[4], s / _elements[5],
+                  s / _elements[6], s / _elements[7], s / _elements[8]);
 }
 
 // MARK: Augmented operator methods - this instance (+)= input
@@ -431,7 +380,6 @@ void Matrix<T, 3, 3>::idiv(T s) {
     _elements[8] /= s;
 }
 
-
 // MARK: Modifiers
 template <typename T>
 void Matrix<T, 3, 3>::transpose() {
@@ -458,7 +406,6 @@ void Matrix<T, 3, 3>::invert() {
 
     set(m);
 }
-
 
 // MARK: Complex getters
 template <typename T>
@@ -502,69 +449,52 @@ T Matrix<T, 3, 3>::trace() const {
 
 template <typename T>
 T Matrix<T, 3, 3>::determinant() const {
-    return
-        _elements[0] * _elements[4] * _elements[8]
-      - _elements[0] * _elements[5] * _elements[7]
-      + _elements[1] * _elements[5] * _elements[6]
-      - _elements[1] * _elements[3] * _elements[8]
-      + _elements[2] * _elements[3] * _elements[7]
-      - _elements[2] * _elements[4] * _elements[6];
+    return _elements[0] * _elements[4] * _elements[8] -
+           _elements[0] * _elements[5] * _elements[7] +
+           _elements[1] * _elements[5] * _elements[6] -
+           _elements[1] * _elements[3] * _elements[8] +
+           _elements[2] * _elements[3] * _elements[7] -
+           _elements[2] * _elements[4] * _elements[6];
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::diagonal() const {
-    return Matrix(
-        _elements[0], 0, 0,
-        0, _elements[4], 0,
-        0, 0, _elements[8]);
+    return Matrix(_elements[0], 0, 0, 0, _elements[4], 0, 0, 0, _elements[8]);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::offDiagonal() const {
-    return Matrix(
-        0, _elements[1], _elements[2],
-        _elements[3], 0, _elements[5],
-        _elements[6], _elements[7], 0);
+    return Matrix(0, _elements[1], _elements[2], _elements[3], 0, _elements[5],
+                  _elements[6], _elements[7], 0);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::strictLowerTri() const {
-    return Matrix(
-        0, 0, 0,
-        _elements[3], 0, 0,
-        _elements[6], _elements[7], 0);
+    return Matrix(0, 0, 0, _elements[3], 0, 0, _elements[6], _elements[7], 0);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::strictUpperTri() const {
-    return Matrix(
-        0, _elements[1], _elements[2],
-        0, 0, _elements[5],
-        0, 0, 0);
+    return Matrix(0, _elements[1], _elements[2], 0, 0, _elements[5], 0, 0, 0);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::lowerTri() const {
-    return Matrix(
-        _elements[0], 0, 0,
-        _elements[3], _elements[4], 0,
-        _elements[6], _elements[7], _elements[8]);
+    return Matrix(_elements[0], 0, 0, _elements[3], _elements[4], 0,
+                  _elements[6], _elements[7], _elements[8]);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::upperTri() const {
-    return Matrix(
-        _elements[0], _elements[1], _elements[2],
-        0, _elements[4], _elements[5],
-        0, 0, _elements[8]);
+    return Matrix(_elements[0], _elements[1], _elements[2], 0, _elements[4],
+                  _elements[5], 0, 0, _elements[8]);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::transposed() const {
-    return Matrix(
-        _elements[0], _elements[3], _elements[6],
-        _elements[1], _elements[4], _elements[7],
-        _elements[2], _elements[5], _elements[8]);
+    return Matrix(_elements[0], _elements[3], _elements[6], _elements[1],
+                  _elements[4], _elements[7], _elements[2], _elements[5],
+                  _elements[8]);
 }
 
 template <typename T>
@@ -575,20 +505,24 @@ Matrix<T, 3, 3> Matrix<T, 3, 3>::inverse() const {
 }
 
 template <typename T>
+T Matrix<T, 3, 3>::frobeniusNorm() const {
+    return std::sqrt(_elements[0] * _elements[0] + _elements[1] * _elements[1] +
+                     _elements[2] * _elements[2] + _elements[3] * _elements[3] +
+                     _elements[4] * _elements[4] + _elements[5] * _elements[5] +
+                     _elements[6] * _elements[6] + _elements[7] * _elements[7] +
+                     _elements[8] * _elements[8]);
+}
+
+template <typename T>
 template <typename U>
 Matrix<U, 3, 3> Matrix<T, 3, 3>::castTo() const {
     return Matrix<U, 3, 3>(
-        static_cast<U>(_elements[0]),
-        static_cast<U>(_elements[1]),
-        static_cast<U>(_elements[2]),
-        static_cast<U>(_elements[3]),
-        static_cast<U>(_elements[4]),
-        static_cast<U>(_elements[5]),
-        static_cast<U>(_elements[6]),
-        static_cast<U>(_elements[7]),
+        static_cast<U>(_elements[0]), static_cast<U>(_elements[1]),
+        static_cast<U>(_elements[2]), static_cast<U>(_elements[3]),
+        static_cast<U>(_elements[4]), static_cast<U>(_elements[5]),
+        static_cast<U>(_elements[6]), static_cast<U>(_elements[7]),
         static_cast<U>(_elements[8]));
 }
-
 
 // MARK: Setter operators
 template <typename T>
@@ -641,32 +575,21 @@ Matrix<T, 3, 3>& Matrix<T, 3, 3>::operator/=(T s) {
 
 template <typename T>
 bool Matrix<T, 3, 3>::operator==(const Matrix& m) const {
-    return
-        _elements[0] == m._elements[0]
-     && _elements[1] == m._elements[1]
-     && _elements[2] == m._elements[2]
-     && _elements[3] == m._elements[3]
-     && _elements[4] == m._elements[4]
-     && _elements[5] == m._elements[5]
-     && _elements[6] == m._elements[6]
-     && _elements[7] == m._elements[7]
-     && _elements[8] == m._elements[8];
+    return _elements[0] == m._elements[0] && _elements[1] == m._elements[1] &&
+           _elements[2] == m._elements[2] && _elements[3] == m._elements[3] &&
+           _elements[4] == m._elements[4] && _elements[5] == m._elements[5] &&
+           _elements[6] == m._elements[6] && _elements[7] == m._elements[7] &&
+           _elements[8] == m._elements[8];
 }
 
 template <typename T>
 bool Matrix<T, 3, 3>::operator!=(const Matrix& m) const {
-    return
-        _elements[0] != m._elements[0]
-     || _elements[1] != m._elements[1]
-     || _elements[2] != m._elements[2]
-     || _elements[3] != m._elements[3]
-     || _elements[4] != m._elements[4]
-     || _elements[5] != m._elements[5]
-     || _elements[6] != m._elements[6]
-     || _elements[7] != m._elements[7]
-     || _elements[8] != m._elements[8];
+    return _elements[0] != m._elements[0] || _elements[1] != m._elements[1] ||
+           _elements[2] != m._elements[2] || _elements[3] != m._elements[3] ||
+           _elements[4] != m._elements[4] || _elements[5] != m._elements[5] ||
+           _elements[6] != m._elements[6] || _elements[7] != m._elements[7] ||
+           _elements[8] != m._elements[8];
 }
-
 
 // MARK: Getter operators
 template <typename T>
@@ -689,30 +612,20 @@ const T& Matrix<T, 3, 3>::operator()(size_t i, size_t j) const {
     return _elements[3 * i + j];
 }
 
-
 // MARK: Helpers
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::makeZero() {
-    return Matrix(
-        0, 0, 0,
-        0, 0, 0,
-        0, 0, 0);
+    return Matrix(0, 0, 0, 0, 0, 0, 0, 0, 0);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::makeIdentity() {
-    return Matrix(
-        1, 0, 0,
-        0, 1, 0,
-        0, 0, 1);
+    return Matrix(1, 0, 0, 0, 1, 0, 0, 0, 1);
 }
 
 template <typename T>
 Matrix<T, 3, 3> Matrix<T, 3, 3>::makeScaleMatrix(T sx, T sy, T sz) {
-    return Matrix(
-        sx, 0, 0,
-        0, sy, 0,
-        0, 0, sz);
+    return Matrix(sx, 0, 0, 0, sy, 0, 0, 0, sz);
 }
 
 template <typename T>
@@ -721,22 +634,21 @@ Matrix<T, 3, 3> Matrix<T, 3, 3>::makeScaleMatrix(const Vector<T, 3>& s) {
 }
 
 template <typename T>
-Matrix<T, 3, 3> Matrix<T, 3, 3>::makeRotationMatrix(
-    const Vector<T, 3>& axis, T rad) {
+Matrix<T, 3, 3> Matrix<T, 3, 3>::makeRotationMatrix(const Vector<T, 3>& axis,
+                                                    T rad) {
     return Matrix(
-        1 + (1 - std::cos(rad))*(axis.x*axis.x - 1),
-        -axis.z*std::sin(rad) + (1 - std::cos(rad))*axis.x*axis.y,
-        axis.y*std::sin(rad) + (1 - std::cos(rad))*axis.x*axis.z,
+        1 + (1 - std::cos(rad)) * (axis.x * axis.x - 1),
+        -axis.z * std::sin(rad) + (1 - std::cos(rad)) * axis.x * axis.y,
+        axis.y * std::sin(rad) + (1 - std::cos(rad)) * axis.x * axis.z,
 
-        axis.z*std::sin(rad) + (1 - std::cos(rad))*axis.x*axis.y,
-        1 + (1 - std::cos(rad))*(axis.y*axis.y - 1),
-        -axis.x*std::sin(rad) + (1 - std::cos(rad))*axis.y*axis.z,
+        axis.z * std::sin(rad) + (1 - std::cos(rad)) * axis.x * axis.y,
+        1 + (1 - std::cos(rad)) * (axis.y * axis.y - 1),
+        -axis.x * std::sin(rad) + (1 - std::cos(rad)) * axis.y * axis.z,
 
-        -axis.y*std::sin(rad) + (1 - std::cos(rad))*axis.x*axis.z,
-        axis.x*std::sin(rad) + (1 - std::cos(rad))*axis.y*axis.z,
-        1 + (1 - std::cos(rad))*(axis.z*axis.z - 1));
+        -axis.y * std::sin(rad) + (1 - std::cos(rad)) * axis.x * axis.z,
+        axis.x * std::sin(rad) + (1 - std::cos(rad)) * axis.y * axis.z,
+        1 + (1 - std::cos(rad)) * (axis.z * axis.z - 1));
 }
-
 
 // MARK: Operator overloadings
 template <typename T>

--- a/include/jet/detail/svd-inl.h
+++ b/include/jet/detail/svd-inl.h
@@ -1,0 +1,576 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+//
+// This implementation is adopted from Numerical Recipes
+// http://numerical.recipes/webnotes/nr3web2.pdf
+//
+
+#ifndef INCLUDE_JET_DETAIL_SVD_H_
+#define INCLUDE_JET_DETAIL_SVD_H_
+
+#include <jet/math_utils.h>
+
+namespace jet {
+
+namespace internal {
+
+template <typename T>
+inline T sign(T a, T b) {
+    return b >= 0.0 ? std::fabs(a) : -std::fabs(a);
+}
+
+template <typename T>
+inline T pythag(T a, T b) {
+    T at = std::fabs(a);
+    T bt = std::fabs(b);
+    T ct;
+    T result;
+
+    if (at > bt) {
+        ct = bt / at;
+        result = at * std::sqrt(1 + ct * ct);
+    } else if (bt > 0) {
+        ct = at / bt;
+        result = bt * std::sqrt(1 + ct * ct);
+    } else {
+        result = 0;
+    }
+
+    return result;
+}
+
+}  // namespace internal
+
+template <typename T>
+void svd(const MatrixMxN<T>& a, MatrixMxN<T>& u, VectorN<T>& w,
+         MatrixMxN<T>& v) {
+    const int m = (int)a.rows();
+    const int n = (int)a.cols();
+
+    int flag, i = 0, its = 0, j = 0, jj = 0, k = 0, l = 0, nm = 0;
+    T c = 0, f = 0, h = 0, s = 0, x = 0, y = 0, z = 0;
+    T anorm = 0, g = 0, scale = 0;
+
+    JET_THROW_INVALID_ARG_WITH_MESSAGE_IF(m < n,
+                                          "Number of rows of input matrix must "
+                                          "be greater than or equal to "
+                                          "columns.");
+
+    // Prepare workspace
+    VectorN<T> rv1(n, 0);
+    u = a;
+    w.resize(n, 0);
+    v.resize(n, n, 0);
+
+    // Householder reduction to bidiagonal form
+    for (i = 0; i < n; i++) {
+        // left-hand reduction
+        l = i + 1;
+        rv1[i] = scale * g;
+        g = s = scale = 0;
+        if (i < m) {
+            for (k = i; k < m; k++) {
+                scale += std::fabs(u(k, i));
+            }
+            if (scale) {
+                for (k = i; k < m; k++) {
+                    u(k, i) /= scale;
+                    s += u(k, i) * u(k, i);
+                }
+                f = u(i, i);
+                g = -internal::sign(std::sqrt(s), f);
+                h = f * g - s;
+                u(i, i) = f - g;
+                if (i != n - 1) {
+                    for (j = l; j < n; j++) {
+                        for (s = 0, k = i; k < m; k++) {
+                            s += u(k, i) * u(k, j);
+                        }
+                        f = s / h;
+                        for (k = i; k < m; k++) {
+                            u(k, j) += f * u(k, i);
+                        }
+                    }
+                }
+                for (k = i; k < m; k++) {
+                    u(k, i) *= scale;
+                }
+            }
+        }
+        w[i] = scale * g;
+
+        // right-hand reduction
+        g = s = scale = 0;
+        if (i < m && i != n - 1) {
+            for (k = l; k < n; k++) {
+                scale += std::fabs(u(i, k));
+            }
+            if (scale) {
+                for (k = l; k < n; k++) {
+                    u(i, k) /= scale;
+                    s += u(i, k) * u(i, k);
+                }
+                f = u(i, l);
+                g = -internal::sign(std::sqrt(s), f);
+                h = f * g - s;
+                u(i, l) = f - g;
+                for (k = l; k < n; k++) {
+                    rv1[k] = (T)u(i, k) / h;
+                }
+                if (i != m - 1) {
+                    for (j = l; j < m; j++) {
+                        for (s = 0, k = l; k < n; k++) {
+                            s += u(j, k) * u(i, k);
+                        }
+                        for (k = l; k < n; k++) {
+                            u(j, k) += s * rv1[k];
+                        }
+                    }
+                }
+                for (k = l; k < n; k++) {
+                    u(i, k) *= scale;
+                }
+            }
+        }
+        anorm = std::max(anorm, (std::fabs((T)w[i]) + std::fabs(rv1[i])));
+    }
+
+    // accumulate the right-hand transformation
+    for (i = n - 1; i >= 0; i--) {
+        if (i < n - 1) {
+            if (g) {
+                for (j = l; j < n; j++) {
+                    v(j, i) = ((u(i, j) / u(i, l)) / g);
+                }
+                // T division to avoid underflow
+                for (j = l; j < n; j++) {
+                    for (s = 0, k = l; k < n; k++) {
+                        s += u(i, k) * v(k, j);
+                    }
+                    for (k = l; k < n; k++) {
+                        v(k, j) += s * v(k, i);
+                    }
+                }
+            }
+            for (j = l; j < n; j++) {
+                v(i, j) = v(j, i) = 0;
+            }
+        }
+        v(i, i) = 1;
+        g = rv1[i];
+        l = i;
+    }
+
+    // accumulate the left-hand transformation
+    for (i = n - 1; i >= 0; i--) {
+        l = i + 1;
+        g = w[i];
+        if (i < n - 1) {
+            for (j = l; j < n; j++) {
+                u(i, j) = 0;
+            }
+        }
+        if (g) {
+            g = 1 / g;
+            if (i != n - 1) {
+                for (j = l; j < n; j++) {
+                    for (s = 0, k = l; k < m; k++) {
+                        s += u(k, i) * u(k, j);
+                    }
+                    f = (s / u(i, i)) * g;
+                    for (k = i; k < m; k++) {
+                        u(k, j) += f * u(k, i);
+                    }
+                }
+            }
+            for (j = i; j < m; j++) {
+                u(j, i) = u(j, i) * g;
+            }
+        } else {
+            for (j = i; j < m; j++) {
+                u(j, i) = 0;
+            }
+        }
+        ++u(i, i);
+    }
+
+    // diagonalize the bidiagonal form
+    for (k = n - 1; k >= 0; k--) {
+        // loop over singular values
+        for (its = 0; its < 30; its++) {
+            // loop over allowed iterations
+            flag = 1;
+            for (l = k; l >= 0; l--) {
+                // test for splitting
+                nm = l - 1;
+                if (std::fabs(rv1[l]) + anorm == anorm) {
+                    flag = 0;
+                    break;
+                }
+                if (std::fabs((T)w[nm]) + anorm == anorm) {
+                    break;
+                }
+            }
+            if (flag) {
+                c = 0;
+                s = 1;
+                for (i = l; i <= k; i++) {
+                    f = s * rv1[i];
+                    if (std::fabs(f) + anorm != anorm) {
+                        g = w[i];
+                        h = internal::pythag(f, g);
+                        w[i] = (T)h;
+                        h = 1 / h;
+                        c = g * h;
+                        s = -f * h;
+                        for (j = 0; j < m; j++) {
+                            y = u(j, nm);
+                            z = u(j, i);
+                            u(j, nm) = y * c + z * s;
+                            u(j, i) = z * c - y * s;
+                        }
+                    }
+                }
+            }
+            z = w[k];
+            if (l == k) {
+                // convergence
+                if (z < 0) {
+                    // make singular value nonnegative
+                    w[k] = -z;
+                    for (j = 0; j < n; j++) {
+                        v(j, k) = -v(j, k);
+                    }
+                }
+                break;
+            }
+            if (its >= 30) {
+                throw("No convergence after 30 iterations");
+            }
+
+            // shift from bottom 2 x 2 minor
+            x = w[l];
+            nm = k - 1;
+            y = w[nm];
+            g = rv1[nm];
+            h = rv1[k];
+            f = ((y - z) * (y + z) + (g - h) * (g + h)) / (2 * h * y);
+            g = internal::pythag(f, (T)1);
+            f = ((x - z) * (x + z) +
+                 h * ((y / (f + internal::sign(g, f))) - h)) /
+                x;
+
+            // next QR transformation
+            c = s = 1;
+            for (j = l; j <= nm; j++) {
+                i = j + 1;
+                g = rv1[i];
+                y = w[i];
+                h = s * g;
+                g = c * g;
+                z = internal::pythag(f, h);
+                rv1[j] = z;
+                c = f / z;
+                s = h / z;
+                f = x * c + g * s;
+                g = g * c - x * s;
+                h = y * s;
+                y = y * c;
+                for (jj = 0; jj < n; jj++) {
+                    x = v(jj, j);
+                    z = v(jj, i);
+                    v(jj, j) = x * c + z * s;
+                    v(jj, i) = z * c - x * s;
+                }
+                z = internal::pythag(f, h);
+                w[j] = z;
+                if (z) {
+                    z = 1 / z;
+                    c = f * z;
+                    s = h * z;
+                }
+                f = (c * g) + (s * y);
+                x = (c * y) - (s * g);
+                for (jj = 0; jj < m; jj++) {
+                    y = u(jj, j);
+                    z = u(jj, i);
+                    u(jj, j) = y * c + z * s;
+                    u(jj, i) = z * c - y * s;
+                }
+            }
+            rv1[l] = 0;
+            rv1[k] = f;
+            w[k] = x;
+        }
+    }
+}
+
+template <typename T, size_t M, size_t N>
+void svd(const Matrix<T, M, N>& a, Matrix<T, M, N>& u, Vector<T, N>& w,
+         Matrix<T, N, N>& v) {
+    const int m = (int)M;
+    const int n = (int)N;
+
+    int flag, i = 0, its = 0, j = 0, jj = 0, k = 0, l = 0, nm = 0;
+    T c = 0, f = 0, h = 0, s = 0, x = 0, y = 0, z = 0;
+    T anorm = 0, g = 0, scale = 0;
+
+    static_assert(M >= N,
+                  "Number of rows of input matrix must be greater than or "
+                  "equal to columns.");
+
+    // Prepare workspace
+    Vector<T, N> rv1;
+    u = a;
+    w = Vector<T, N>();
+    v = Matrix<T, N, N>();
+
+    // Householder reduction to bidiagonal form
+    for (i = 0; i < n; i++) {
+        // left-hand reduction
+        l = i + 1;
+        rv1[i] = scale * g;
+        g = s = scale = 0;
+        if (i < m) {
+            for (k = i; k < m; k++) {
+                scale += std::fabs(u(k, i));
+            }
+            if (scale) {
+                for (k = i; k < m; k++) {
+                    u(k, i) /= scale;
+                    s += u(k, i) * u(k, i);
+                }
+                f = u(i, i);
+                g = -internal::sign(std::sqrt(s), f);
+                h = f * g - s;
+                u(i, i) = f - g;
+                if (i != n - 1) {
+                    for (j = l; j < n; j++) {
+                        for (s = 0, k = i; k < m; k++) {
+                            s += u(k, i) * u(k, j);
+                        }
+                        f = s / h;
+                        for (k = i; k < m; k++) {
+                            u(k, j) += f * u(k, i);
+                        }
+                    }
+                }
+                for (k = i; k < m; k++) {
+                    u(k, i) *= scale;
+                }
+            }
+        }
+        w[i] = scale * g;
+
+        // right-hand reduction
+        g = s = scale = 0;
+        if (i < m && i != n - 1) {
+            for (k = l; k < n; k++) {
+                scale += std::fabs(u(i, k));
+            }
+            if (scale) {
+                for (k = l; k < n; k++) {
+                    u(i, k) /= scale;
+                    s += u(i, k) * u(i, k);
+                }
+                f = u(i, l);
+                g = -internal::sign(std::sqrt(s), f);
+                h = f * g - s;
+                u(i, l) = f - g;
+                for (k = l; k < n; k++) {
+                    rv1[k] = (T)u(i, k) / h;
+                }
+                if (i != m - 1) {
+                    for (j = l; j < m; j++) {
+                        for (s = 0, k = l; k < n; k++) {
+                            s += u(j, k) * u(i, k);
+                        }
+                        for (k = l; k < n; k++) {
+                            u(j, k) += s * rv1[k];
+                        }
+                    }
+                }
+                for (k = l; k < n; k++) {
+                    u(i, k) *= scale;
+                }
+            }
+        }
+        anorm = std::max(anorm, (std::fabs((T)w[i]) + std::fabs(rv1[i])));
+    }
+
+    // accumulate the right-hand transformation
+    for (i = n - 1; i >= 0; i--) {
+        if (i < n - 1) {
+            if (g) {
+                for (j = l; j < n; j++) {
+                    v(j, i) = ((u(i, j) / u(i, l)) / g);
+                }
+                // T division to avoid underflow
+                for (j = l; j < n; j++) {
+                    for (s = 0, k = l; k < n; k++) {
+                        s += u(i, k) * v(k, j);
+                    }
+                    for (k = l; k < n; k++) {
+                        v(k, j) += s * v(k, i);
+                    }
+                }
+            }
+            for (j = l; j < n; j++) {
+                v(i, j) = v(j, i) = 0;
+            }
+        }
+        v(i, i) = 1;
+        g = rv1[i];
+        l = i;
+    }
+
+    // accumulate the left-hand transformation
+    for (i = n - 1; i >= 0; i--) {
+        l = i + 1;
+        g = w[i];
+        if (i < n - 1) {
+            for (j = l; j < n; j++) {
+                u(i, j) = 0;
+            }
+        }
+        if (g) {
+            g = 1 / g;
+            if (i != n - 1) {
+                for (j = l; j < n; j++) {
+                    for (s = 0, k = l; k < m; k++) {
+                        s += u(k, i) * u(k, j);
+                    }
+                    f = (s / u(i, i)) * g;
+                    for (k = i; k < m; k++) {
+                        u(k, j) += f * u(k, i);
+                    }
+                }
+            }
+            for (j = i; j < m; j++) {
+                u(j, i) = u(j, i) * g;
+            }
+        } else {
+            for (j = i; j < m; j++) {
+                u(j, i) = 0;
+            }
+        }
+        ++u(i, i);
+    }
+
+    // diagonalize the bidiagonal form
+    for (k = n - 1; k >= 0; k--) {
+        // loop over singular values
+        for (its = 0; its < 30; its++) {
+            // loop over allowed iterations
+            flag = 1;
+            for (l = k; l >= 0; l--) {
+                // test for splitting
+                nm = l - 1;
+                if (std::fabs(rv1[l]) + anorm == anorm) {
+                    flag = 0;
+                    break;
+                }
+                if (std::fabs((T)w[nm]) + anorm == anorm) {
+                    break;
+                }
+            }
+            if (flag) {
+                c = 0;
+                s = 1;
+                for (i = l; i <= k; i++) {
+                    f = s * rv1[i];
+                    if (std::fabs(f) + anorm != anorm) {
+                        g = w[i];
+                        h = internal::pythag(f, g);
+                        w[i] = (T)h;
+                        h = 1 / h;
+                        c = g * h;
+                        s = -f * h;
+                        for (j = 0; j < m; j++) {
+                            y = u(j, nm);
+                            z = u(j, i);
+                            u(j, nm) = y * c + z * s;
+                            u(j, i) = z * c - y * s;
+                        }
+                    }
+                }
+            }
+            z = w[k];
+            if (l == k) {
+                // convergence
+                if (z < 0) {
+                    // make singular value nonnegative
+                    w[k] = -z;
+                    for (j = 0; j < n; j++) {
+                        v(j, k) = -v(j, k);
+                    }
+                }
+                break;
+            }
+            if (its >= 30) {
+                throw("No convergence after 30 iterations");
+            }
+
+            // shift from bottom 2 x 2 minor
+            x = w[l];
+            nm = k - 1;
+            y = w[nm];
+            g = rv1[nm];
+            h = rv1[k];
+            f = ((y - z) * (y + z) + (g - h) * (g + h)) / (2 * h * y);
+            g = internal::pythag(f, (T)1);
+            f = ((x - z) * (x + z) +
+                 h * ((y / (f + internal::sign(g, f))) - h)) /
+                x;
+
+            // next QR transformation
+            c = s = 1;
+            for (j = l; j <= nm; j++) {
+                i = j + 1;
+                g = rv1[i];
+                y = w[i];
+                h = s * g;
+                g = c * g;
+                z = internal::pythag(f, h);
+                rv1[j] = z;
+                c = f / z;
+                s = h / z;
+                f = x * c + g * s;
+                g = g * c - x * s;
+                h = y * s;
+                y = y * c;
+                for (jj = 0; jj < n; jj++) {
+                    x = v(jj, j);
+                    z = v(jj, i);
+                    v(jj, j) = x * c + z * s;
+                    v(jj, i) = z * c - x * s;
+                }
+                z = internal::pythag(f, h);
+                w[j] = z;
+                if (z) {
+                    z = 1 / z;
+                    c = f * z;
+                    s = h * z;
+                }
+                f = (c * g) + (s * y);
+                x = (c * y) - (s * g);
+                for (jj = 0; jj < m; jj++) {
+                    y = u(jj, j);
+                    z = u(jj, i);
+                    u(jj, j) = y * c + z * s;
+                    u(jj, i) = z * c - y * s;
+                }
+            }
+            rv1[l] = 0;
+            rv1[k] = f;
+            w[k] = x;
+        }
+    }
+}
+
+}  // namespace jet
+
+#endif  // INCLUDE_JET_DETAIL_SVD_H_

--- a/include/jet/jet.h
+++ b/include/jet/jet.h
@@ -9,6 +9,8 @@
 #include <jet/advection_solver2.h>
 #include <jet/advection_solver3.h>
 #include <jet/animation.h>
+#include <jet/anisotropic_points_to_implicit2.h>
+#include <jet/anisotropic_points_to_implicit3.h>
 #include <jet/apic_solver2.h>
 #include <jet/apic_solver3.h>
 #include <jet/array.h>
@@ -186,6 +188,8 @@
 #include <jet/point_particle_emitter3.h>
 #include <jet/point_simple_list_searcher2.h>
 #include <jet/point_simple_list_searcher3.h>
+#include <jet/points_to_implicit2.h>
+#include <jet/points_to_implicit3.h>
 #include <jet/quadtree.h>
 #include <jet/quaternion.h>
 #include <jet/ray.h>
@@ -207,18 +211,23 @@
 #include <jet/size3.h>
 #include <jet/sph_kernels2.h>
 #include <jet/sph_kernels3.h>
+#include <jet/sph_points_to_implicit2.h>
+#include <jet/sph_points_to_implicit3.h>
 #include <jet/sph_solver2.h>
 #include <jet/sph_solver3.h>
 #include <jet/sph_system_data2.h>
 #include <jet/sph_system_data3.h>
 #include <jet/sphere2.h>
 #include <jet/sphere3.h>
+#include <jet/spherical_points_to_implicit2.h>
+#include <jet/spherical_points_to_implicit3.h>
 #include <jet/surface2.h>
 #include <jet/surface3.h>
 #include <jet/surface_set2.h>
 #include <jet/surface_set3.h>
 #include <jet/surface_to_implicit2.h>
 #include <jet/surface_to_implicit3.h>
+#include <jet/svd.h>
 #include <jet/timer.h>
 #include <jet/transform2.h>
 #include <jet/transform3.h>
@@ -247,4 +256,6 @@
 #include <jet/volume_grid_emitter3.h>
 #include <jet/volume_particle_emitter2.h>
 #include <jet/volume_particle_emitter3.h>
+#include <jet/zhu_bridson_points_to_implicit2.h>
+#include <jet/zhu_bridson_points_to_implicit3.h>
 #endif  // INCLUDE_JET_JET_H_

--- a/include/jet/macros.h
+++ b/include/jet/macros.h
@@ -36,6 +36,8 @@
 #include <stdexcept>
 #define JET_THROW_INVALID_ARG_IF(expression) \
     if (expression) { throw std::invalid_argument(#expression); }
+#define JET_THROW_INVALID_ARG_WITH_MESSAGE_IF(expression, message) \
+    if (expression) { throw std::invalid_argument(message); }
 #endif
 
 #ifdef JET_WINDOWS

--- a/include/jet/matrix2x2.h
+++ b/include/jet/matrix2x2.h
@@ -264,6 +264,9 @@ class Matrix<T, 2, 2> {
     //! Returns inverse matrix.
     Matrix inverse() const;
 
+    //! Returns Frobenius norm.
+    T frobeniusNorm() const;
+
     template <typename U>
     Matrix<U, 2, 2> castTo() const;
 

--- a/include/jet/matrix3x3.h
+++ b/include/jet/matrix3x3.h
@@ -267,6 +267,9 @@ class Matrix<T, 3, 3> {
     //! Returns inverse matrix.
     Matrix inverse() const;
 
+    //! Returns Frobenius norm.
+    T frobeniusNorm() const;
+
     template <typename U>
     Matrix<U, 3, 3> castTo() const;
 

--- a/include/jet/points_to_implicit2.h
+++ b/include/jet/points_to_implicit2.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef INCLUDE_JET_POINTS_TO_IMPLICIT2_H_
+#define INCLUDE_JET_POINTS_TO_IMPLICIT2_H_
+
+#include <jet/array_accessor1.h>
+#include <jet/scalar_grid2.h>
+#include <jet/vector2.h>
+
+#include <memory>
+
+namespace jet {
+
+//! Abstract base class for 2-D points-to-implicit converters.
+class PointsToImplicit2 {
+ public:
+    //! Default constructor.
+    PointsToImplicit2();
+
+    //! Default destructor.
+    virtual ~PointsToImplicit2();
+
+    //! Converts the given points to implicit surface scalar field.
+    virtual void convert(const ConstArrayAccessor1<Vector2D>& points,
+                         ScalarGrid2* output) const = 0;
+};
+
+//! Shared pointer for the PointsToImplicit2 type.
+typedef std::shared_ptr<PointsToImplicit2> PointsToImplicit2Ptr;
+
+}  // namespace jet
+
+#endif  // INCLUDE_JET_POINTS_TO_IMPLICIT2_H_

--- a/include/jet/points_to_implicit3.h
+++ b/include/jet/points_to_implicit3.h
@@ -1,0 +1,37 @@
+// Copyright (c) 3017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef INCLUDE_JET_POINTS_TO_IMPLICIT3_H_
+#define INCLUDE_JET_POINTS_TO_IMPLICIT3_H_
+
+#include <jet/array_accessor1.h>
+#include <jet/scalar_grid3.h>
+#include <jet/vector3.h>
+
+#include <memory>
+
+namespace jet {
+
+//! Abstract base class for 3-D points-to-implicit converters.
+class PointsToImplicit3 {
+ public:
+    //! Default constructor.
+    PointsToImplicit3();
+
+    //! Default destructor.
+    virtual ~PointsToImplicit3();
+
+    //! Converts the given points to implicit surface scalar field.
+    virtual void convert(const ConstArrayAccessor1<Vector3D>& points,
+                         ScalarGrid3* output) const = 0;
+};
+
+//! Shared pointer for the PointsToImplicit3 type.
+typedef std::shared_ptr<PointsToImplicit3> PointsToImplicit3Ptr;
+
+}  // namespace jet
+
+#endif  // INCLUDE_JET_POINTS_TO_IMPLICIT3_H_

--- a/include/jet/sph_points_to_implicit2.h
+++ b/include/jet/sph_points_to_implicit2.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef INCLUDE_JET_SPH_POINTS_TO_IMPLICIT2_H_
+#define INCLUDE_JET_SPH_POINTS_TO_IMPLICIT2_H_
+
+#include <jet/points_to_implicit2.h>
+
+namespace jet {
+
+//!
+//! \brief 2-D points-to-implicit converter based on standard SPH kernel.
+//!
+//! \see Müller, Matthias, David Charypar, and Markus Gross.
+//!      "Particle-based fluid simulation for interactive applications."
+//!      Proceedings of the 2003 ACM SIGGRAPH/Eurographics symposium on Computer
+//!      animation. Eurographics Association, 2003.
+//!
+class SphPointsToImplicit2 final : public PointsToImplicit2 {
+ public:
+    //! Constructs the converter with given kernel radius and cut-off density.
+    SphPointsToImplicit2(double kernelRadius = 1.0, double cutOffDensity = 0.5);
+
+    //! Converts the given points to implicit surface scalar field.
+    void convert(const ConstArrayAccessor1<Vector2D>& points,
+                 ScalarGrid2* output) const override;
+
+ private:
+    double _kernelRadius = 1.0;
+    double _cutOffDensity = 0.5;
+};
+
+//! Shared pointer type for SphPointsToImplicit2 class.
+typedef std::shared_ptr<SphPointsToImplicit2> SphPointsToImplicit2Ptr;
+
+}  // namespace jet
+
+#endif  // INCLUDE_JET_SPH_POINTS_TO_IMPLICIT2_H_

--- a/include/jet/sph_points_to_implicit3.h
+++ b/include/jet/sph_points_to_implicit3.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef INCLUDE_JET_SPH_POINTS_TO_IMPLICIT3_H_
+#define INCLUDE_JET_SPH_POINTS_TO_IMPLICIT3_H_
+
+#include <jet/points_to_implicit3.h>
+
+namespace jet {
+
+//!
+//! \brief 3-D points-to-implicit converter based on standard SPH kernel.
+//!
+//! \see Müller, Matthias, David Charypar, and Markus Gross.
+//!      "Particle-based fluid simulation for interactive applications."
+//!      Proceedings of the 2003 ACM SIGGRAPH/Eurographics symposium on Computer
+//!      animation. Eurographics Association, 2003.
+//!
+class SphPointsToImplicit3 final : public PointsToImplicit3 {
+ public:
+    //! Constructs the converter with given kernel radius and cut-off density.
+    SphPointsToImplicit3(double kernelRadius = 1.0, double cutOffDensity = 0.5);
+
+    //! Converts the given points to implicit surface scalar field.
+    void convert(const ConstArrayAccessor1<Vector3D>& points,
+                 ScalarGrid3* output) const override;
+
+ private:
+    double _kernelRadius = 1.0;
+    double _cutOffDensity = 0.5;
+};
+
+//! Shared pointer type for SphPointsToImplicit3 class.
+typedef std::shared_ptr<SphPointsToImplicit3> SphPointsToImplicit3Ptr;
+
+}  // namespace jet
+
+#endif  // INCLUDE_JET_SPH_POINTS_TO_IMPLICIT3_H_

--- a/include/jet/spherical_points_to_implicit2.h
+++ b/include/jet/spherical_points_to_implicit2.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef INCLUDE_JET_SPHERICAL_POINTS_TO_IMPLICIT2_H_
+#define INCLUDE_JET_SPHERICAL_POINTS_TO_IMPLICIT2_H_
+
+#include <jet/points_to_implicit2.h>
+
+namespace jet {
+
+//!
+//! \brief 2-D points-to-implicit converter based on simple sphere model.
+//!
+class SphericalPointsToImplicit2 final : public PointsToImplicit2 {
+ public:
+    //! Constructs the converter with given sphere radius.
+    SphericalPointsToImplicit2(double radius = 1.0);
+
+    //! Converts the given points to implicit surface scalar field.
+    void convert(const ConstArrayAccessor1<Vector2D>& points,
+                 ScalarGrid2* output) const override;
+
+ private:
+    double _radius = 1.0;
+};
+
+//! Shared pointer type for SphericalPointsToImplicit2.
+typedef std::shared_ptr<SphericalPointsToImplicit2>
+    SphericalPointsToImplicit2Ptr;
+
+}  // namespace jet
+
+#endif  // INCLUDE_JET_SPHERICAL_POINTS_TO_IMPLICIT2_H_

--- a/include/jet/spherical_points_to_implicit3.h
+++ b/include/jet/spherical_points_to_implicit3.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef INCLUDE_JET_SPHERICAL_POINTS_TO_IMPLICIT3_H_
+#define INCLUDE_JET_SPHERICAL_POINTS_TO_IMPLICIT3_H_
+
+#include <jet/points_to_implicit3.h>
+
+namespace jet {
+
+//!
+//! \brief 3-D points-to-implicit converter based on simple sphere model.
+//!
+class SphericalPointsToImplicit3 final : public PointsToImplicit3 {
+ public:
+    //! Constructs the converter with given sphere radius.
+    SphericalPointsToImplicit3(double radius = 1.0);
+
+    //! Converts the given points to implicit surface scalar field.
+    void convert(const ConstArrayAccessor1<Vector3D>& points,
+                 ScalarGrid3* output) const override;
+
+ private:
+    double _radius = 1.0;
+};
+
+//! Shared pointer type for SphericalPointsToImplicit3.
+typedef std::shared_ptr<SphericalPointsToImplicit3>
+    SphericalPointsToImplicit3Ptr;
+
+}  // namespace jet
+
+#endif  // INCLUDE_JET_SPHERICAL_POINTS_TO_IMPLICIT3_H_

--- a/include/jet/svd.h
+++ b/include/jet/svd.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef INCLUDE_JET_SVD_H_
+#define INCLUDE_JET_SVD_H_
+
+#include <jet/matrix2x2.h>
+#include <jet/matrix3x3.h>
+#include <jet/matrix4x4.h>
+#include <jet/matrix_mxn.h>
+
+namespace jet {
+
+//!
+//! \brief Singular value decomposition (SVD).
+//!
+//! This function decompose the input matrix \p a to \p u * \p w * \p v^T.
+//!
+//! \tparam T Real-value type.
+//!
+//! \param a The input matrix to decompose.
+//! \param u Left-most output matrix.
+//! \param w The vector of singular values.
+//! \param v Right-most output matrix.
+//!
+template <typename T>
+void svd(const MatrixMxN<T>& a, MatrixMxN<T>& u, VectorN<T>& w,
+         MatrixMxN<T>& v);
+
+//!
+//! \brief Singular value decomposition (SVD).
+//!
+//! This function decompose the input matrix \p a to \p u * \p w * \p v^T.
+//!
+//! \tparam T Real-value type.
+//!
+//! \param a The input matrix to decompose.
+//! \param u Left-most output matrix.
+//! \param w The vector of singular values.
+//! \param v Right-most output matrix.
+//!
+template <typename T, size_t M, size_t N>
+void svd(const Matrix<T, M, N>& a, Matrix<T, M, N>& u, Vector<T, N>& w,
+         Matrix<T, N, N>& v);
+
+}  // namespace jet
+
+#include "detail/svd-inl.h"
+
+#endif  // INCLUDE_JET_SVD_H_

--- a/include/jet/zhu_bridson_points_to_implicit2.h
+++ b/include/jet/zhu_bridson_points_to_implicit2.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef INCLUDE_JET_ZHU_BRIDSON_POINTS_TO_IMPLICIT2_H_
+#define INCLUDE_JET_ZHU_BRIDSON_POINTS_TO_IMPLICIT2_H_
+
+#include <jet/points_to_implicit2.h>
+
+namespace jet {
+
+//!
+//! \brief 2-D points-to-implicit converter based on Zhu and Bridson's method.
+//!
+//! \see Zhu, Yongning, and Robert Bridson. "Animating sand as a fluid."
+//!      ACM Transactions on Graphics (TOG). Vol. 24. No. 3. ACM, 2005.
+//!
+class ZhuBridsonPointsToImplicit2 final : public PointsToImplicit2 {
+ public:
+    //! Constructs the converter with given kernel radius and cut-off threshold.
+    ZhuBridsonPointsToImplicit2(double kernelRadius = 1.0,
+                                double cutOffThreshold = 0.25);
+
+    //! Converts the given points to implicit surface scalar field.
+    void convert(const ConstArrayAccessor1<Vector2D>& points,
+                 ScalarGrid2* output) const override;
+
+ private:
+    double _kernelRadius = 1.0;
+    double _cutOffThreshold = 0.25;
+};
+
+//! Shared pointer type for ZhuBridsonPointsToImplicit2 class
+typedef std::shared_ptr<ZhuBridsonPointsToImplicit2> ZhuBridsonPointsToImplicit2Ptr;
+
+}  // namespace jet
+
+#endif  // INCLUDE_JET_ZHU_BRIDSON_POINTS_TO_IMPLICIT2_H_

--- a/include/jet/zhu_bridson_points_to_implicit3.h
+++ b/include/jet/zhu_bridson_points_to_implicit3.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef INCLUDE_JET_ZHU_BRIDSON_POINTS_TO_IMPLICIT3_H_
+#define INCLUDE_JET_ZHU_BRIDSON_POINTS_TO_IMPLICIT3_H_
+
+#include <jet/points_to_implicit3.h>
+
+namespace jet {
+
+//!
+//! \brief 3-D points-to-implicit converter based on Zhu and Bridson's method.
+//!
+//! \see Zhu, Yongning, and Robert Bridson. "Animating sand as a fluid."
+//!      ACM Transactions on Graphics (TOG). Vol. 24. No. 3. ACM, 2005.
+//!
+class ZhuBridsonPointsToImplicit3 final : public PointsToImplicit3 {
+ public:
+    //! Constructs the converter with given kernel radius and cut-off threshold.
+    ZhuBridsonPointsToImplicit3(double kernelRadius = 1.0,
+                                double cutOffThreshold = 0.25);
+
+    //! Converts the given points to implicit surface scalar field.
+    void convert(const ConstArrayAccessor1<Vector3D>& points,
+                 ScalarGrid3* output) const override;
+
+ private:
+    double _kernelRadius = 1.0;
+    double _cutOffThreshold = 0.25;
+};
+
+//! Shared pointer type for ZhuBridsonPointsToImplicit3 class
+typedef std::shared_ptr<ZhuBridsonPointsToImplicit3> ZhuBridsonPointsToImplicit3Ptr;
+
+}  // namespace jet
+
+#endif  // INCLUDE_JET_ZHU_BRIDSON_POINTS_TO_IMPLICIT3_H_

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -300,9 +300,10 @@ def render_still_scalar_grid2(filename, output_filename, **kwargs):
     im = ax.imshow(grid_data, cmap=plt.cm.gray, interpolation=interpolation)
     if has_iso:
         if has_iso_colors:
-            plt.contour(grid_data, 10, colors=iso_colors)
+            cs = plt.contour(grid_data, 10, colors=iso_colors)
         else:
-            plt.contour(grid_data, 10)
+            cs = plt.contour(grid_data, 10)
+        plt.clabel(cs, inline=1, fontsize=10)
     if has_colorbar:
         plt.colorbar(im)
     plt.savefig(output_filename)

--- a/src/examples/python_examples/apic_example01.py
+++ b/src/examples/python_examples/apic_example01.py
@@ -24,7 +24,8 @@ def main():
 
     # Setup emitter
     sphere = Sphere3(center=(0.5, 1.0, 0.5), radius=0.15)
-    emitter = VolumeParticleEmitter3(implicitSurface=sphere, spacing=1.0 / (2 * resX))
+    emitter = VolumeParticleEmitter3(
+        implicitSurface=sphere, spacing=1.0 / (2 * resX))
     solver.particleEmitter = emitter
 
     # Setup collider

--- a/src/examples/python_examples/apic_example02.py
+++ b/src/examples/python_examples/apic_example02.py
@@ -28,7 +28,8 @@ def main():
 
     # Setup emitter
     sphere = Sphere3(center=(0.5, 1.0, 0.5), radius=0.15)
-    emitter = VolumeParticleEmitter3(implicitSurface=sphere, spacing=1.0 / (2 * resX))
+    emitter = VolumeParticleEmitter3(
+        implicitSurface=sphere, spacing=1.0 / (2 * resX))
     solver.particleEmitter = emitter
 
     # Setup collider

--- a/src/examples/python_examples/points_to_implicit.py
+++ b/src/examples/python_examples/points_to_implicit.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2017 Doyub Kim
+
+I am making my contributions/submissions to this project solely in my personal
+capacity and am not conveying any rights to any intellectual property of any
+third parties.
+"""
+
+from pyjet import *
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def main():
+    np.random.seed(0)
+    points = np.random.rand(100, 2) * 0.6 + 0.2
+
+    grid = CellCenteredScalarGrid2((512, 512), (1.0 / 512.0, 1.0 / 512.0))
+
+    fig, ax = plt.subplots()
+    ax.set_aspect("equal")
+
+    kernel_radius = 0.1
+    cutoff = 0.5
+
+    converter = SphericalPointsToImplicit2(kernel_radius * cutoff)
+    converter.convert(points.tolist(), grid)
+    plt.contour(grid.dataAccessor(), levels=[0.0], colors=("g"))
+
+    converter = SphPointsToImplicit2(kernel_radius, cutoff)
+    converter.convert(points.tolist(), grid)
+    plt.contour(grid.dataAccessor(), levels=[0.0], colors=("b"))
+
+    converter = ZhuBridsonPointsToImplicit2(2.0 * kernel_radius, 0.5 * cutoff)
+    converter.convert(points.tolist(), grid)
+    plt.contour(grid.dataAccessor(), levels=[0.0], colors=("purple"))
+
+    converter = AnisotropicPointsToImplicit2(kernel_radius, cutoff, 0.0, 8)
+    converter.convert(points.tolist(), grid)
+    plt.contour(grid.dataAccessor(), levels=[0.0], colors=("r"))
+
+    plt.scatter(points[:, 0] * 512, points[:, 1] * 512, c="black")
+    plt.show()
+
+
+if __name__ == "__main__":
+    Logging.mute()
+    main()

--- a/src/examples/python_examples/smoke_example01.py
+++ b/src/examples/python_examples/smoke_example01.py
@@ -43,6 +43,7 @@ def main():
 
     # Animation
     frame = Frame(0, 1.0 / ANIM_FPS)
+
     def updatefig(*args):
         solver.update(frame)
         frame.advance()

--- a/src/jet/anisotropic_points_to_implicit2.cpp
+++ b/src/jet/anisotropic_points_to_implicit2.cpp
@@ -1,0 +1,180 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <pch.h>
+
+#include <jet/anisotropic_points_to_implicit2.h>
+#include <jet/fmm_level_set_solver2.h>
+#include <jet/jet.h>
+#include <jet/sph_kernels2.h>
+#include <jet/sph_system_data2.h>
+#include <jet/svd.h>
+
+using namespace jet;
+
+inline double p(double distance) {
+    const double distanceSquared = distance * distance;
+
+    if (distanceSquared >= 1.0) {
+        return 0.0;
+    } else {
+        const double x = 1.0 - distanceSquared;
+        return x * x * x;
+    }
+}
+
+inline double wij(double distance, double r) {
+    if (distance < r) {
+        return 1.0 - cubic(distance / r);
+    } else {
+        return 0.0;
+    }
+}
+
+inline Matrix2x2D vvt(const Vector2D& v) {
+    return Matrix2x2D(v.x * v.x, v.x * v.y, v.y * v.x, v.y * v.y);
+}
+
+inline double w(const Vector2D& r, const Matrix2x2D& g, double gDet) {
+    static const double sigma = 4.0 / kPiD;
+    return sigma * gDet * p((g * r).length());
+}
+
+//
+
+AnisotropicPointsToImplicit2::AnisotropicPointsToImplicit2(
+    double kernelRadius, double cutOffDensity, double positionSmoothingFactor,
+    size_t minNumNeighbors)
+    : _kernelRadius(kernelRadius),
+      _cutOffDensity(cutOffDensity),
+      _positionSmoothingFactor(positionSmoothingFactor),
+      _minNumNeighbors(minNumNeighbors) {}
+
+void AnisotropicPointsToImplicit2::convert(
+    const ConstArrayAccessor1<Vector2D>& points, ScalarGrid2* output) const {
+    if (output == nullptr) {
+        JET_WARN << "Null scalar grid output pointer provided.";
+        return;
+    }
+
+    const auto res = output->resolution();
+    if (res.x * res.y == 0) {
+        JET_WARN << "Empty grid is provided.";
+        return;
+    }
+
+    const auto bbox = output->boundingBox();
+    if (bbox.isEmpty()) {
+        JET_WARN << "Empty domain is provided.";
+        return;
+    }
+
+    const double h = _kernelRadius;
+    const double invH = 1 / h;
+    const double r = 2.0 * h;
+
+    // Mean estimator for cov. mat.
+    ParticleSystemData2 meanParticles;
+    meanParticles.addParticles(points);
+    meanParticles.buildNeighborSearcher(r);
+    const auto meanNeighborSearcher = meanParticles.neighborSearcher();
+
+    // Compute G and xMean
+    std::vector<Matrix2x2D> gs(points.size());
+    std::vector<Vector2D> xMeans(points.size());
+
+    parallelFor(kZeroSize, points.size(), [&](size_t i) {
+        const auto& x = points[i];
+
+        // Compute xMean
+        Vector2D xMean;
+        double wSum = 0.0;
+        size_t numNeighbors = 0;
+        const auto getXMean = [&](size_t, const Vector2D& xj) {
+            const double wj = wij((x - xj).length(), r);
+            wSum += wj;
+            xMean += wj * xj;
+            ++numNeighbors;
+        };
+        meanNeighborSearcher->forEachNearbyPoint(x, r, getXMean);
+
+        JET_ASSERT(wSum > 0.0);
+        xMean /= wSum;
+
+        xMeans[i] = lerp(x, xMean, _positionSmoothingFactor);
+
+        if (numNeighbors < _minNumNeighbors) {
+            const auto g = Matrix2x2D::makeScaleMatrix(invH, invH);
+            gs[i] = g;
+        } else {
+            // Compute covariance matrix
+            // We start with small scale matrix (h*h) in order to
+            // prevent zero covariance matrix when points are all
+            // perfectly lined up.
+            auto cov = Matrix2x2D::makeScaleMatrix(h * h, h * h);
+            wSum = 0.0;
+            const auto getCov = [&](size_t, const Vector2D& xj) {
+                const double wj = wij((xMean - xj).length(), r);
+                wSum += wj;
+                cov += wj * vvt(xj - xMean);
+            };
+            meanNeighborSearcher->forEachNearbyPoint(x, r, getCov);
+
+            cov /= wSum;
+
+            // SVD
+            Matrix2x2D u;
+            Vector2D v;
+            Matrix2x2D w;
+            svd(cov, u, v, w);
+
+            // Constrain Sigma
+            const double maxSingularVal = v.absmax();
+            const double kr = 4.0;
+            v[0] = std::max(v[0], maxSingularVal / kr);
+            v[1] = std::max(v[1], maxSingularVal / kr);
+            const auto invSigma = Matrix2x2D::makeScaleMatrix(1.0 / v);
+
+            // Compute G
+            const double relA = v[0] * v[1];  // area preservation
+            const Matrix2x2D g =
+                invH * std::sqrt(relA) * (w * invSigma * u.transposed());
+            gs[i] = g;
+        }
+    });
+
+    // SPH estimator
+    SphSystemData2 sphParticles;
+    sphParticles.addParticles(
+        ConstArrayAccessor1<Vector2D>(xMeans.size(), xMeans.data()));
+    sphParticles.setKernelRadius(h);
+    sphParticles.buildNeighborSearcher();
+    sphParticles.updateDensities();
+    const auto d = sphParticles.densities();
+    const double m = sphParticles.mass();
+
+    meanParticles.resize(0);
+    meanParticles.addParticles(
+        ConstArrayAccessor1<Vector2D>(xMeans.size(), xMeans.data()));
+    meanParticles.buildNeighborSearcher(r);
+    const auto meanNeighborSearcher2 = meanParticles.neighborSearcher();
+
+    // Compute SDF
+    auto temp = output->clone();
+    temp->fill([&](const Vector2D& x) {
+        double sum = 0.0;
+        meanNeighborSearcher2->forEachNearbyPoint(
+            x, r, [&](size_t i, const Vector2D& neighborPosition) {
+                sum += m / d[i] *
+                       w(neighborPosition - x, gs[i], gs[i].determinant());
+            });
+
+        return _cutOffDensity - sum;
+    });
+
+    FmmLevelSetSolver2 solver;
+    solver.reinitialize(*temp, kMaxD, output);
+}

--- a/src/jet/anisotropic_points_to_implicit3.cpp
+++ b/src/jet/anisotropic_points_to_implicit3.cpp
@@ -1,0 +1,182 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <pch.h>
+
+#include <jet/anisotropic_points_to_implicit3.h>
+#include <jet/fmm_level_set_solver3.h>
+#include <jet/jet.h>
+#include <jet/sph_kernels3.h>
+#include <jet/sph_system_data3.h>
+#include <jet/svd.h>
+
+using namespace jet;
+
+inline double p(double distance) {
+    const double distanceSquared = distance * distance;
+
+    if (distanceSquared >= 1.0) {
+        return 0.0;
+    } else {
+        const double x = 1.0 - distanceSquared;
+        return x * x * x;
+    }
+}
+
+inline double wij(double distance, double r) {
+    if (distance < r) {
+        return 1.0 - cubic(distance / r);
+    } else {
+        return 0.0;
+    }
+}
+
+inline Matrix3x3D vvt(const Vector3D& v) {
+    return Matrix3x3D(v.x * v.x, v.x * v.y, v.x * v.z, v.y * v.x, v.y * v.y,
+                      v.y * v.z, v.z * v.x, v.z * v.y, v.z * v.z);
+}
+
+inline double w(const Vector3D& r, const Matrix3x3D& g, double gDet) {
+    static const double sigma = 315.0 / (64 * kPiD);
+    return sigma * gDet * p((g * r).length());
+}
+
+//
+
+AnisotropicPointsToImplicit3::AnisotropicPointsToImplicit3(
+    double kernelRadius, double cutOffDensity, double positionSmoothingFactor,
+    size_t minNumNeighbors)
+    : _kernelRadius(kernelRadius),
+      _cutOffDensity(cutOffDensity),
+      _positionSmoothingFactor(positionSmoothingFactor),
+      _minNumNeighbors(minNumNeighbors) {}
+
+void AnisotropicPointsToImplicit3::convert(
+    const ConstArrayAccessor1<Vector3D>& points, ScalarGrid3* output) const {
+    if (output == nullptr) {
+        JET_WARN << "Null scalar grid output pointer provided.";
+        return;
+    }
+
+    const auto res = output->resolution();
+    if (res.x * res.y * res.z == 0) {
+        JET_WARN << "Empty grid is provided.";
+        return;
+    }
+
+    const auto bbox = output->boundingBox();
+    if (bbox.isEmpty()) {
+        JET_WARN << "Empty domain is provided.";
+        return;
+    }
+
+    const double h = _kernelRadius;
+    const double invH = 1 / h;
+    const double r = 2.0 * h;
+
+    // Mean estimator for cov. mat.
+    ParticleSystemData3 meanParticles;
+    meanParticles.addParticles(points);
+    meanParticles.buildNeighborSearcher(r);
+    const auto meanNeighborSearcher = meanParticles.neighborSearcher();
+
+    // Compute G and xMean
+    std::vector<Matrix3x3D> gs(points.size());
+    std::vector<Vector3D> xMeans(points.size());
+
+    parallelFor(kZeroSize, points.size(), [&](size_t i) {
+        const auto& x = points[i];
+
+        // Compute xMean
+        Vector3D xMean;
+        double wSum = 0.0;
+        size_t numNeighbors = 0;
+        const auto getXMean = [&](size_t, const Vector3D& xj) {
+            const double wj = wij((x - xj).length(), r);
+            wSum += wj;
+            xMean += wj * xj;
+            ++numNeighbors;
+        };
+        meanNeighborSearcher->forEachNearbyPoint(x, r, getXMean);
+
+        JET_ASSERT(wSum > 0.0);
+        xMean /= wSum;
+
+        xMeans[i] = lerp(x, xMean, _positionSmoothingFactor);
+
+        if (numNeighbors < _minNumNeighbors) {
+            const auto g = Matrix3x3D::makeScaleMatrix(invH, invH, invH);
+            gs[i] = g;
+        } else {
+            // Compute covariance matrix
+            // We start with small scale matrix (h*h) in order to
+            // prevent zero covariance matrix when points are all
+            // perfectly lined up.
+            auto cov = Matrix3x3D::makeScaleMatrix(h * h, h * h, h * h);
+            wSum = 0.0;
+            const auto getCov = [&](size_t, const Vector3D& xj) {
+                const double wj = wij((xMean - xj).length(), r);
+                wSum += wj;
+                cov += wj * vvt(xj - xMean);
+            };
+            meanNeighborSearcher->forEachNearbyPoint(x, r, getCov);
+
+            cov /= wSum;
+
+            // SVD
+            Matrix3x3D u;
+            Vector3D v;
+            Matrix3x3D w;
+            svd(cov, u, v, w);
+
+            // Constrain Sigma
+            const double maxSingularVal = v.absmax();
+            const double kr = 4.0;
+            v[0] = std::max(v[0], maxSingularVal / kr);
+            v[1] = std::max(v[1], maxSingularVal / kr);
+            v[2] = std::max(v[2], maxSingularVal / kr);
+            const auto invSigma = Matrix3x3D::makeScaleMatrix(1.0 / v);
+
+            // Compute G
+            const double relV = v[0] * v[1] * v[2];  // area preservation
+            const Matrix3x3D g = invH * std::pow(relV, 1.0 / 3.0) *
+                                 (w * invSigma * u.transposed());
+            gs[i] = g;
+        }
+    });
+
+    // SPH estimator
+    SphSystemData3 sphParticles;
+    sphParticles.addParticles(
+        ConstArrayAccessor1<Vector3D>(xMeans.size(), xMeans.data()));
+    sphParticles.setKernelRadius(h);
+    sphParticles.buildNeighborSearcher();
+    sphParticles.updateDensities();
+    const auto d = sphParticles.densities();
+    const double m = sphParticles.mass();
+
+    meanParticles.resize(0);
+    meanParticles.addParticles(
+        ConstArrayAccessor1<Vector3D>(xMeans.size(), xMeans.data()));
+    meanParticles.buildNeighborSearcher(r);
+    const auto meanNeighborSearcher3 = meanParticles.neighborSearcher();
+
+    // Compute SDF
+    auto temp = output->clone();
+    temp->fill([&](const Vector3D& x) {
+        double sum = 0.0;
+        meanNeighborSearcher3->forEachNearbyPoint(
+            x, r, [&](size_t i, const Vector3D& neighborPosition) {
+                sum += m / d[i] *
+                       w(neighborPosition - x, gs[i], gs[i].determinant());
+            });
+
+        return _cutOffDensity - sum;
+    });
+
+    FmmLevelSetSolver3 solver;
+    solver.reinitialize(*temp, kMaxD, output);
+}

--- a/src/jet/points_to_implicit2.cpp
+++ b/src/jet/points_to_implicit2.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <pch.h>
+
+#include <jet/points_to_implicit2.h>
+
+using namespace jet;
+
+PointsToImplicit2::PointsToImplicit2() {}
+
+PointsToImplicit2::~PointsToImplicit2() {}

--- a/src/jet/points_to_implicit3.cpp
+++ b/src/jet/points_to_implicit3.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <pch.h>
+
+#include <jet/points_to_implicit3.h>
+
+using namespace jet;
+
+PointsToImplicit3::PointsToImplicit3() {}
+
+PointsToImplicit3::~PointsToImplicit3() {}

--- a/src/jet/sph_points_to_implicit2.cpp
+++ b/src/jet/sph_points_to_implicit2.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <pch.h>
+
+#include <jet/fmm_level_set_solver2.h>
+#include <jet/sph_points_to_implicit2.h>
+#include <jet/sph_system_data2.h>
+
+using namespace jet;
+
+SphPointsToImplicit2::SphPointsToImplicit2(double kernelRadius,
+                                           double cutOffDensity)
+    : _kernelRadius(kernelRadius), _cutOffDensity(cutOffDensity) {}
+
+void SphPointsToImplicit2::convert(const ConstArrayAccessor1<Vector2D>& points,
+                                   ScalarGrid2* output) const {
+    if (output == nullptr) {
+        JET_WARN << "Null scalar grid output pointer provided.";
+        return;
+    }
+
+    const auto res = output->resolution();
+    if (res.x * res.y == 0) {
+        JET_WARN << "Empty grid is provided.";
+        return;
+    }
+
+    const auto bbox = output->boundingBox();
+    if (bbox.isEmpty()) {
+        JET_WARN << "Empty domain is provided.";
+        return;
+    }
+
+    SphSystemData2 sphParticles;
+    sphParticles.addParticles(points);
+    sphParticles.setKernelRadius(_kernelRadius);
+    sphParticles.buildNeighborSearcher();
+    sphParticles.updateDensities();
+
+    Array1<double> constData(sphParticles.numberOfParticles(), 1.0);
+    auto temp = output->clone();
+    temp->fill([&](const Vector2D& x) {
+        double d = sphParticles.interpolate(x, constData);
+        return _cutOffDensity - d;
+    });
+
+    FmmLevelSetSolver2 solver;
+    solver.reinitialize(*temp, kMaxD, output);
+}

--- a/src/jet/sph_points_to_implicit3.cpp
+++ b/src/jet/sph_points_to_implicit3.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <pch.h>
+
+#include <jet/fmm_level_set_solver3.h>
+#include <jet/sph_points_to_implicit3.h>
+#include <jet/sph_system_data3.h>
+
+using namespace jet;
+
+SphPointsToImplicit3::SphPointsToImplicit3(double kernelRadius,
+                                           double cutOffDensity)
+    : _kernelRadius(kernelRadius), _cutOffDensity(cutOffDensity) {}
+
+void SphPointsToImplicit3::convert(const ConstArrayAccessor1<Vector3D>& points,
+                                   ScalarGrid3* output) const {
+    if (output == nullptr) {
+        JET_WARN << "Null scalar grid output pointer provided.";
+        return;
+    }
+
+    const auto res = output->resolution();
+    if (res.x * res.y * res.z == 0) {
+        JET_WARN << "Empty grid is provided.";
+        return;
+    }
+
+    const auto bbox = output->boundingBox();
+    if (bbox.isEmpty()) {
+        JET_WARN << "Empty domain is provided.";
+        return;
+    }
+
+    SphSystemData3 sphParticles;
+    sphParticles.addParticles(points);
+    sphParticles.setKernelRadius(_kernelRadius);
+    sphParticles.buildNeighborSearcher();
+    sphParticles.updateDensities();
+
+    Array1<double> constData(sphParticles.numberOfParticles(), 1.0);
+    auto temp = output->clone();
+    temp->fill([&](const Vector3D& x) {
+        double d = sphParticles.interpolate(x, constData);
+        return _cutOffDensity - d;
+    });
+
+    FmmLevelSetSolver3 solver;
+    solver.reinitialize(*temp, kMaxD, output);
+}

--- a/src/jet/spherical_points_to_implicit2.cpp
+++ b/src/jet/spherical_points_to_implicit2.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <pch.h>
+
+#include <jet/fmm_level_set_solver2.h>
+#include <jet/particle_system_data2.h>
+#include <jet/spherical_points_to_implicit2.h>
+
+using namespace jet;
+
+SphericalPointsToImplicit2::SphericalPointsToImplicit2(double radius)
+    : _radius(radius) {}
+
+void SphericalPointsToImplicit2::convert(
+    const ConstArrayAccessor1<Vector2D>& points, ScalarGrid2* output) const {
+    if (output == nullptr) {
+        JET_WARN << "Null scalar grid output pointer provided.";
+        return;
+    }
+
+    const auto res = output->resolution();
+    if (res.x * res.y == 0) {
+        JET_WARN << "Empty grid is provided.";
+        return;
+    }
+
+    const auto bbox = output->boundingBox();
+    if (bbox.isEmpty()) {
+        JET_WARN << "Empty domain is provided.";
+        return;
+    }
+
+    ParticleSystemData2 particles;
+    particles.addParticles(points);
+    particles.buildNeighborSearcher(2.0 * _radius);
+
+    const auto neighborSearcher = particles.neighborSearcher();
+
+    auto temp = output->clone();
+    temp->fill([&](const Vector2D& x) {
+        double minDist = kMaxD;
+        neighborSearcher->forEachNearbyPoint(
+            x, 2.0 * _radius, [&](size_t, const Vector2D& xj) {
+                minDist = std::min(minDist, (x - xj).length());
+            });
+
+        return minDist - _radius;
+    });
+
+    FmmLevelSetSolver2 solver;
+    solver.reinitialize(*temp, kMaxD, output);
+}

--- a/src/jet/spherical_points_to_implicit3.cpp
+++ b/src/jet/spherical_points_to_implicit3.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <pch.h>
+
+#include <jet/fmm_level_set_solver3.h>
+#include <jet/particle_system_data3.h>
+#include <jet/spherical_points_to_implicit3.h>
+
+using namespace jet;
+
+SphericalPointsToImplicit3::SphericalPointsToImplicit3(double radius)
+    : _radius(radius) {}
+
+void SphericalPointsToImplicit3::convert(
+    const ConstArrayAccessor1<Vector3D>& points, ScalarGrid3* output) const {
+    if (output == nullptr) {
+        JET_WARN << "Null scalar grid output pointer provided.";
+        return;
+    }
+
+    const auto res = output->resolution();
+    if (res.x * res.y * res.z == 0) {
+        JET_WARN << "Empty grid is provided.";
+        return;
+    }
+
+    const auto bbox = output->boundingBox();
+    if (bbox.isEmpty()) {
+        JET_WARN << "Empty domain is provided.";
+        return;
+    }
+
+    ParticleSystemData3 particles;
+    particles.addParticles(points);
+    particles.buildNeighborSearcher(3.0 * _radius);
+
+    const auto neighborSearcher = particles.neighborSearcher();
+
+    auto temp = output->clone();
+    temp->fill([&](const Vector3D& x) {
+        double minDist = kMaxD;
+        neighborSearcher->forEachNearbyPoint(
+            x, 2.0 * _radius, [&](size_t, const Vector3D& xj) {
+                minDist = std::min(minDist, (x - xj).length());
+            });
+
+        return minDist - _radius;
+    });
+
+    FmmLevelSetSolver3 solver;
+    solver.reinitialize(*temp, kMaxD, output);
+}

--- a/src/jet/zhu_bridson_points_to_implicit2.cpp
+++ b/src/jet/zhu_bridson_points_to_implicit2.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <pch.h>
+
+#include <jet/fmm_level_set_solver2.h>
+#include <jet/particle_system_data2.h>
+#include <jet/zhu_bridson_points_to_implicit2.h>
+
+using namespace jet;
+
+inline double k(double s) { return std::max(0.0, cubic(1.0 - s * s)); }
+
+ZhuBridsonPointsToImplicit2::ZhuBridsonPointsToImplicit2(double kernelRadius,
+                                                         double cutOffThreshold)
+    : _kernelRadius(kernelRadius), _cutOffThreshold(cutOffThreshold) {}
+
+void ZhuBridsonPointsToImplicit2::convert(
+    const ConstArrayAccessor1<Vector2D>& points, ScalarGrid2* output) const {
+    if (output == nullptr) {
+        JET_WARN << "Null scalar grid output pointer provided.";
+        return;
+    }
+
+    const auto res = output->resolution();
+    if (res.x * res.y == 0) {
+        JET_WARN << "Empty grid is provided.";
+        return;
+    }
+
+    const auto bbox = output->boundingBox();
+    if (bbox.isEmpty()) {
+        JET_WARN << "Empty domain is provided.";
+        return;
+    }
+
+    ParticleSystemData2 particles;
+    particles.addParticles(points);
+    particles.buildNeighborSearcher(_kernelRadius);
+
+    const auto neighborSearcher = particles.neighborSearcher();
+    const double isoContValue = _cutOffThreshold * _kernelRadius;
+
+    auto temp = output->clone();
+    temp->fill([&](const Vector2D& x) -> double {
+        Vector2D xAvg;
+        double wSum = 0.0;
+        const auto func = [&](size_t, const Vector2D& xi) {
+            const double wi = k((x - xi).length() / _kernelRadius);
+
+            wSum += wi;
+            xAvg += wi * xi;
+        };
+        neighborSearcher->forEachNearbyPoint(x, _kernelRadius, func);
+
+        if (wSum > 0.0) {
+            xAvg /= wSum;
+            return (x - xAvg).length() - isoContValue;
+        } else {
+            return output->boundingBox().diagonalLength();
+        }
+    });
+
+    FmmLevelSetSolver2 solver;
+    solver.reinitialize(*temp, kMaxD, output);
+}

--- a/src/jet/zhu_bridson_points_to_implicit3.cpp
+++ b/src/jet/zhu_bridson_points_to_implicit3.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <pch.h>
+
+#include <jet/fmm_level_set_solver3.h>
+#include <jet/particle_system_data3.h>
+#include <jet/zhu_bridson_points_to_implicit3.h>
+
+using namespace jet;
+
+inline double k(double s) { return std::max(0.0, cubic(1.0 - s * s)); }
+
+ZhuBridsonPointsToImplicit3::ZhuBridsonPointsToImplicit3(double kernelRadius,
+                                                         double cutOffThreshold)
+    : _kernelRadius(kernelRadius), _cutOffThreshold(cutOffThreshold) {}
+
+void ZhuBridsonPointsToImplicit3::convert(
+    const ConstArrayAccessor1<Vector3D>& points, ScalarGrid3* output) const {
+    if (output == nullptr) {
+        JET_WARN << "Null scalar grid output pointer provided.";
+        return;
+    }
+
+    const auto res = output->resolution();
+    if (res.x * res.y * res.z == 0) {
+        JET_WARN << "Empty grid is provided.";
+        return;
+    }
+
+    const auto bbox = output->boundingBox();
+    if (bbox.isEmpty()) {
+        JET_WARN << "Empty domain is provided.";
+        return;
+    }
+
+    ParticleSystemData3 particles;
+    particles.addParticles(points);
+    particles.buildNeighborSearcher(_kernelRadius);
+
+    const auto neighborSearcher = particles.neighborSearcher();
+    const double isoContValue = _cutOffThreshold * _kernelRadius;
+
+    auto temp = output->clone();
+    temp->fill([&](const Vector3D& x) -> double {
+        Vector3D xAvg;
+        double wSum = 0.0;
+        const auto func = [&](size_t, const Vector3D& xi) {
+            const double wi = k((x - xi).length() / _kernelRadius);
+            wSum += wi;
+            xAvg += wi * xi;
+        };
+        neighborSearcher->forEachNearbyPoint(x, _kernelRadius, func);
+
+        if (wSum > 0.0) {
+            xAvg /= wSum;
+            return (x - xAvg).length() - isoContValue;
+        } else {
+            return output->boundingBox().diagonalLength();
+        }
+    });
+
+    FmmLevelSetSolver3 solver;
+    solver.reinitialize(*temp, kMaxD, output);
+}

--- a/src/python/anisotropic_points_to_implicit.cpp
+++ b/src/python/anisotropic_points_to_implicit.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "anisotropic_points_to_implicit.h"
+#include "pybind11_utils.h"
+
+#include <jet/anisotropic_points_to_implicit2.h>
+#include <jet/anisotropic_points_to_implicit3.h>
+
+namespace py = pybind11;
+using namespace jet;
+
+void addAnisotropicPointsToImplicit2(pybind11::module& m) {
+    py::class_<AnisotropicPointsToImplicit2, PointsToImplicit2,
+               AnisotropicPointsToImplicit2Ptr>(m,
+                                                "AnisotropicPointsToImplicit2",
+                                                R"pbdoc(
+        2-D points-to-implicit converter using Anisotropic kernels.
+
+        \see Yu, Jihun, and Greg Turk. "Reconstructing surfaces of particle-based
+             fluids using anisotropic kernels." ACM Transactions on Graphics (TOG)
+             32.1 (2013): 5.
+        )pbdoc")
+        .def(py::init<double, double, double, size_t>(),
+             R"pbdoc(
+             Constructs the converter with given kernel radius and cut-off density.
+
+             Parameters
+             ----------
+             - kernelRadius : Smoothing kernel radius.
+             - cutOffDensity : Iso-contour value.
+             - positionSmoothingFactor : Position smoothing factor.
+             - minNumNeighbors : Minimum number of neighbors to enable anisotropic kernel.
+             )pbdoc",
+             py::arg("kernelRadius") = 1.0, py::arg("cutOffDensity") = 0.5,
+             py::arg("positionSmoothingFactor") = 0.95,
+             py::arg("minNumNeighbors") = 8);
+}
+
+void addAnisotropicPointsToImplicit3(pybind11::module& m) {
+    py::class_<AnisotropicPointsToImplicit3, PointsToImplicit3,
+               AnisotropicPointsToImplicit3Ptr>(m,
+                                                "AnisotropicPointsToImplicit3",
+                                                R"pbdoc(
+        3-D points-to-implicit converter using Anisotropic kernels.
+
+        \see Yu, Jihun, and Greg Turk. "Reconstructing surfaces of particle-based
+             fluids using anisotropic kernels." ACM Transactions on Graphics (TOG)
+             32.1 (2013): 5.
+        )pbdoc")
+        .def(py::init<double, double, double, size_t>(),
+             R"pbdoc(
+             Constructs the converter with given kernel radius and cut-off density.
+
+             Parameters
+             ----------
+             - kernelRadius : Smoothing kernel radius.
+             - cutOffDensity : Iso-contour value.
+             - positionSmoothingFactor : Position smoothing factor.
+             - minNumNeighbors : Minimum number of neighbors to enable anisotropic kernel.
+             )pbdoc",
+             py::arg("kernelRadius") = 1.0, py::arg("cutOffDensity") = 0.5,
+             py::arg("positionSmoothingFactor") = 0.95,
+             py::arg("minNumNeighbors") = 25);
+}

--- a/src/python/anisotropic_points_to_implicit.h
+++ b/src/python/anisotropic_points_to_implicit.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef SRC_PYTHON_ANISOTROPIC_POINTS_TO_IMPLICIT_H_
+#define SRC_PYTHON_ANISOTROPIC_POINTS_TO_IMPLICIT_H_
+
+#include <pybind11/pybind11.h>
+
+void addAnisotropicPointsToImplicit2(pybind11::module& m);
+void addAnisotropicPointsToImplicit3(pybind11::module& m);
+
+#endif  // SRC_PYTHON_ANISOTROPIC_POINTS_TO_IMPLICIT_H_

--- a/src/python/bounding_box.cpp
+++ b/src/python/bounding_box.cpp
@@ -64,16 +64,14 @@ void addBoundingBox2F(pybind11::module& m) {
              Parameters
              ----------
              - axis : 0 or 1.
-             )pbdoc",
-             py::arg("axis"))
+             )pbdoc", py::arg("axis"))
         .def("overlaps", &BoundingBox2F::overlaps, R"pbdoc(
              Returns true of this box and other box overlaps.
 
              Parameters
              ----------
              - other : Other bounding box to test with.
-             )pbdoc",
-             py::arg("other"))
+             )pbdoc", py::arg("other"))
         .def("contains",
              [](const BoundingBox2F& instance, py::object point) {
                  return instance.contains(objectToVector2F(point));
@@ -149,24 +147,24 @@ void addBoundingBox2F(pybind11::module& m) {
              Parameters
              ----------
              - delta : Amount to expand.
-             )pbdoc",
-             py::arg("delta"))
+             )pbdoc", py::arg("delta"))
         .def("corner", &BoundingBox2F::corner, R"pbdoc(
              Returns corner position. Index starts from x-first order.
 
              Parameters
              ----------
              - idx : Index of the corner.
-             )pbdoc",
-             py::arg("idx"))
+             )pbdoc", py::arg("idx"))
         .def("clamp", &BoundingBox2F::clamp, R"pbdoc(
              Returns the clamped point.
 
              Parameters
              ----------
              - point : Point to clamp.
-             )pbdoc",
-             py::arg("point"));
+             )pbdoc", py::arg("point"))
+        .def("isEmpty", &BoundingBox2F::isEmpty, R"pbdoc(
+             Returns true if the box is empty.
+             )pbdoc");
 }
 
 void addBoundingBox2D(pybind11::module& m) {
@@ -220,16 +218,14 @@ void addBoundingBox2D(pybind11::module& m) {
              Parameters
              ----------
              - axis : 0 or 1.
-             )pbdoc",
-             py::arg("axis"))
+             )pbdoc", py::arg("axis"))
         .def("overlaps", &BoundingBox2D::overlaps, R"pbdoc(
              Returns true of this box and other box overlaps.
 
              Parameters
              ----------
              - other : Other bounding box to test with.
-             )pbdoc",
-             py::arg("other"))
+             )pbdoc", py::arg("other"))
         .def("contains",
              [](const BoundingBox2D& instance, py::object point) {
                  return instance.contains(objectToVector2D(point));
@@ -305,24 +301,24 @@ void addBoundingBox2D(pybind11::module& m) {
              Parameters
              ----------
              - delta : Amount to expand.
-             )pbdoc",
-             py::arg("delta"))
+             )pbdoc", py::arg("delta"))
         .def("corner", &BoundingBox2D::corner, R"pbdoc(
              Returns corner position. Index starts from x-first order.
 
              Parameters
              ----------
              - idx : Index of the corner.
-             )pbdoc",
-             py::arg("idx"))
+             )pbdoc", py::arg("idx"))
         .def("clamp", &BoundingBox2D::clamp, R"pbdoc(
              Returns the clamped point.
 
              Parameters
              ----------
              - point : Point to clamp.
-             )pbdoc",
-             py::arg("point"));
+             )pbdoc", py::arg("point"))
+        .def("isEmpty", &BoundingBox2D::isEmpty, R"pbdoc(
+             Returns true if the box is empty.
+             )pbdoc");
 }
 
 void addBoundingBox3F(pybind11::module& m) {
@@ -378,16 +374,14 @@ void addBoundingBox3F(pybind11::module& m) {
              Parameters
              ----------
              - axis : 0, 1, or 2.
-             )pbdoc",
-             py::arg("axis"))
+             )pbdoc", py::arg("axis"))
         .def("overlaps", &BoundingBox3F::overlaps, R"pbdoc(
              Returns true of this box and other box overlaps.
 
              Parameters
              ----------
              - other : Other bounding box to test with.
-             )pbdoc",
-             py::arg("other"))
+             )pbdoc", py::arg("other"))
         .def("contains",
              [](const BoundingBox3F& instance, py::object point) {
                  return instance.contains(objectToVector3F(point));
@@ -463,24 +457,24 @@ void addBoundingBox3F(pybind11::module& m) {
              Parameters
              ----------
              - delta : Amount to expand.
-             )pbdoc",
-             py::arg("delta"))
+             )pbdoc", py::arg("delta"))
         .def("corner", &BoundingBox3F::corner, R"pbdoc(
              Returns corner position. Index starts from x-first order.
 
              Parameters
              ----------
              - idx : Index of the corner.
-             )pbdoc",
-             py::arg("idx"))
+             )pbdoc", py::arg("idx"))
         .def("clamp", &BoundingBox3F::clamp, R"pbdoc(
              Returns the clamped point.
 
              Parameters
              ----------
              - point : Point to clamp.
-             )pbdoc",
-             py::arg("point"));
+             )pbdoc", py::arg("point"))
+        .def("isEmpty", &BoundingBox3F::isEmpty, R"pbdoc(
+             Returns true if the box is empty.
+             )pbdoc");
 }
 
 void addBoundingBox3D(pybind11::module& m) {
@@ -536,16 +530,14 @@ void addBoundingBox3D(pybind11::module& m) {
              Parameters
              ----------
              - axis : 0, 1, or 2.
-             )pbdoc",
-             py::arg("axis"))
+             )pbdoc", py::arg("axis"))
         .def("overlaps", &BoundingBox3D::overlaps, R"pbdoc(
              Returns true of this box and other box overlaps.
 
              Parameters
              ----------
              - other : Other bounding box to test with.
-             )pbdoc",
-             py::arg("other"))
+             )pbdoc", py::arg("other"))
         .def("contains",
              [](const BoundingBox3D& instance, py::object point) {
                  return instance.contains(objectToVector3D(point));
@@ -621,22 +613,22 @@ void addBoundingBox3D(pybind11::module& m) {
              Parameters
              ----------
              - delta : Amount to expand.
-             )pbdoc",
-             py::arg("delta"))
+             )pbdoc", py::arg("delta"))
         .def("corner", &BoundingBox3D::corner, R"pbdoc(
              Returns corner position. Index starts from x-first order.
 
              Parameters
              ----------
              - idx : Index of the corner.
-             )pbdoc",
-             py::arg("idx"))
+             )pbdoc", py::arg("idx"))
         .def("clamp", &BoundingBox3D::clamp, R"pbdoc(
              Returns the clamped point.
 
              Parameters
              ----------
              - point : Point to clamp.
-             )pbdoc",
-             py::arg("point"));
+             )pbdoc", py::arg("point"))
+        .def("isEmpty", &BoundingBox3D::isEmpty, R"pbdoc(
+             Returns true if the box is empty.
+             )pbdoc");
 }

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -6,6 +6,7 @@
 
 #include "advection_solver.h"
 #include "animation.h"
+#include "anisotropic_points_to_implicit.h"
 #include "apic_solver.h"
 #include "array_accessor.h"
 #include "bounding_box.h"
@@ -63,6 +64,7 @@
 #include "plane.h"
 #include "point.h"
 #include "point_particle_emitter.h"
+#include "points_to_implicit.h"
 #include "quaternion.h"
 #include "ray.h"
 #include "rigid_body_collider.h"
@@ -71,9 +73,11 @@
 #include "semi_lagrangian.h"
 #include "serializable.h"
 #include "size.h"
+#include "sph_points_to_implicit.h"
 #include "sph_solver.h"
 #include "sph_system_data.h"
 #include "sphere.h"
+#include "spherical_points_to_implicit.h"
 #include "surface.h"
 #include "surface_set.h"
 #include "surface_to_implicit.h"
@@ -88,6 +92,7 @@
 #include "vertex_centered_vector_grid.h"
 #include "volume_grid_emitter.h"
 #include "volume_particle_emitter.h"
+#include "zhu_bridson_points_to_implicit.h"
 
 #include <pybind11/pybind11.h>
 
@@ -267,6 +272,16 @@ PYBIND11_PLUGIN(pyjet) {
     addEnoLevelSetSolver3(m);
     addFmmLevelSetSolver2(m);
     addFmmLevelSetSolver3(m);
+    addPointsToImplicit2(m);
+    addPointsToImplicit3(m);
+    addSphericalPointsToImplicit2(m);
+    addSphericalPointsToImplicit3(m);
+    addSphPointsToImplicit2(m);
+    addSphPointsToImplicit3(m);
+    addZhuBridsonPointsToImplicit2(m);
+    addZhuBridsonPointsToImplicit3(m);
+    addAnisotropicPointsToImplicit2(m);
+    addAnisotropicPointsToImplicit3(m);
 
     // Animations
     addAnimation(m);

--- a/src/python/points_to_implicit.cpp
+++ b/src/python/points_to_implicit.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "points_to_implicit.h"
+#include "pybind11_utils.h"
+
+#include <jet/points_to_implicit2.h>
+#include <jet/points_to_implicit3.h>
+
+namespace py = pybind11;
+using namespace jet;
+
+void addPointsToImplicit2(pybind11::module& m) {
+    py::class_<PointsToImplicit2, PointsToImplicit2Ptr>(m, "PointsToImplicit2",
+                                                        R"pbdoc(
+        Abstract base class for 2-D points-to-implicit converters.
+        )pbdoc")
+        .def("convert",
+             [](const PointsToImplicit2& instance, const py::list& points,
+                ScalarGrid2Ptr output) {
+                 std::vector<Vector2D> points_;
+                 for (size_t i = 0; i < points.size(); ++i) {
+                     points_.push_back(objectToVector2D(points[i]));
+                 }
+                 ConstArrayAccessor1<Vector2D> pointsAcc(points_.size(),
+                                                         points_.data());
+                 instance.convert(pointsAcc, output.get());
+             },
+             R"pbdoc(
+             Converts the given points to implicit surface scalar field.
+
+             Parameters
+             ----------
+             - points : List of 2D vectors.
+             - output : Scalar grid output.
+             )pbdoc",
+             py::arg("points"), py::arg("output"));
+}
+
+void addPointsToImplicit3(pybind11::module& m) {
+    py::class_<PointsToImplicit3, PointsToImplicit3Ptr>(m, "PointsToImplicit3",
+                                                        R"pbdoc(
+        Abstract base class for 3-D points-to-implicit converters.
+        )pbdoc")
+        .def("convert",
+             [](const PointsToImplicit3& instance, const py::list& points,
+                ScalarGrid3Ptr output) {
+                 std::vector<Vector3D> points_;
+                 for (size_t i = 0; i < points.size(); ++i) {
+                     points_.push_back(objectToVector3D(points[i]));
+                 }
+                 ConstArrayAccessor1<Vector3D> pointsAcc(points_.size(),
+                                                         points_.data());
+                 instance.convert(pointsAcc, output.get());
+             },
+             R"pbdoc(
+             Converts the given points to implicit surface scalar field.
+
+             Parameters
+             ----------
+             - points : List of 3D vectors.
+             - output : Scalar grid output.
+             )pbdoc",
+             py::arg("points"), py::arg("output"));
+}

--- a/src/python/points_to_implicit.h
+++ b/src/python/points_to_implicit.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef SRC_PYTHON_POINTS_TO_IMPLICIT_H_
+#define SRC_PYTHON_POINTS_TO_IMPLICIT_H_
+
+#include <pybind11/pybind11.h>
+
+void addPointsToImplicit2(pybind11::module& m);
+void addPointsToImplicit3(pybind11::module& m);
+
+#endif  // SRC_PYTHON_POINTS_TO_IMPLICIT_H_

--- a/src/python/pybind11_utils.h
+++ b/src/python/pybind11_utils.h
@@ -17,6 +17,7 @@
 #include <jet/vector4.h>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace jet {
 
@@ -26,6 +27,19 @@ inline Size2 tupleToSize2(pybind11::tuple tpl) {
     if (tpl.size() == 2) {
         for (size_t i = 0; i < 2; ++i) {
             ret[i] = tpl[i].cast<size_t>();
+        }
+    } else {
+        throw std::invalid_argument("Invalid size.");
+    }
+    return ret;
+}
+
+inline Size2 tupleToSize2(pybind11::list lst) {
+    Size2 ret;
+
+    if (lst.size() == 2) {
+        for (size_t i = 0; i < 2; ++i) {
+            ret[i] = lst[i].cast<size_t>();
         }
     } else {
         throw std::invalid_argument("Invalid size.");
@@ -46,6 +60,19 @@ inline Size3 tupleToSize3(pybind11::tuple tpl) {
     return ret;
 }
 
+inline Size3 tupleToSize3(pybind11::list lst) {
+    Size3 ret;
+
+    if (lst.size() == 3) {
+        for (size_t i = 0; i < 3; ++i) {
+            ret[i] = lst[i].cast<size_t>();
+        }
+    } else {
+        throw std::invalid_argument("Invalid size.");
+    }
+    return ret;
+}
+
 inline Point2UI tupleToPoint2UI(pybind11::tuple tpl) {
     Point2UI ret;
 
@@ -59,12 +86,38 @@ inline Point2UI tupleToPoint2UI(pybind11::tuple tpl) {
     return ret;
 }
 
+inline Point2UI tupleToPoint2UI(pybind11::list lst) {
+    Point2UI ret;
+
+    if (lst.size() == 2) {
+        for (size_t i = 0; i < 2; ++i) {
+            ret[i] = lst[i].cast<size_t>();
+        }
+    } else {
+        throw std::invalid_argument("Invalid size.");
+    }
+    return ret;
+}
+
 inline Point3UI tupleToPoint3UI(pybind11::tuple tpl) {
     Point3UI ret;
 
     if (tpl.size() == 3) {
         for (size_t i = 0; i < 3; ++i) {
             ret[i] = tpl[i].cast<size_t>();
+        }
+    } else {
+        throw std::invalid_argument("Invalid size.");
+    }
+    return ret;
+}
+
+inline Point3UI tupleToPoint3UI(pybind11::list lst) {
+    Point3UI ret;
+
+    if (lst.size() == 3) {
+        for (size_t i = 0; i < 3; ++i) {
+            ret[i] = lst[i].cast<size_t>();
         }
     } else {
         throw std::invalid_argument("Invalid size.");
@@ -96,8 +149,33 @@ inline Vector<T, N> tupleToVector(pybind11::tuple tpl) {
     return ret;
 }
 
+template <typename T, size_t N>
+inline Vector<T, N> tupleToVector(pybind11::list tpl) {
+    Vector<T, N> ret;
+
+    if (tpl.size() == N) {
+        for (size_t i = 0; i < N; ++i) {
+            ret[i] = tpl[i].cast<T>();
+        }
+    } else {
+        throw std::invalid_argument("Invalid size.");
+    }
+    return ret;
+}
+
 template <typename T>
 inline Quaternion<T> tupleToQuaternion(pybind11::tuple tpl) {
+    Quaternion<T> ret;
+
+    for (size_t i = 0; i < 4; ++i) {
+        ret[i] = tpl[i].cast<T>();
+    }
+
+    return ret;
+}
+
+template <typename T>
+inline Quaternion<T> tupleToQuaternion(pybind11::list tpl) {
     Quaternion<T> ret;
 
     for (size_t i = 0; i < 4; ++i) {
@@ -111,7 +189,15 @@ inline Vector2F tupleToVector2F(pybind11::tuple tpl) {
     return tupleToVector<float, 2>(tpl);
 }
 
+inline Vector2F tupleToVector2F(pybind11::list tpl) {
+    return tupleToVector<float, 2>(tpl);
+}
+
 inline Vector3F tupleToVector3F(pybind11::tuple tpl) {
+    return tupleToVector<float, 3>(tpl);
+}
+
+inline Vector3F tupleToVector3F(pybind11::list tpl) {
     return tupleToVector<float, 3>(tpl);
 }
 
@@ -119,7 +205,15 @@ inline Vector4F tupleToVector4F(pybind11::tuple tpl) {
     return tupleToVector<float, 4>(tpl);
 }
 
+inline Vector4F tupleToVector4F(pybind11::list tpl) {
+    return tupleToVector<float, 4>(tpl);
+}
+
 inline QuaternionF tupleToQuaternionF(pybind11::tuple tpl) {
+    return tupleToQuaternion<float>(tpl);
+}
+
+inline QuaternionF tupleToQuaternionF(pybind11::list tpl) {
     return tupleToQuaternion<float>(tpl);
 }
 
@@ -127,11 +221,23 @@ inline Vector2D tupleToVector2D(pybind11::tuple tpl) {
     return tupleToVector<double, 2>(tpl);
 }
 
+inline Vector2D tupleToVector2D(pybind11::list tpl) {
+    return tupleToVector<double, 2>(tpl);
+}
+
 inline Vector3D tupleToVector3D(pybind11::tuple tpl) {
     return tupleToVector<double, 3>(tpl);
 }
 
+inline Vector3D tupleToVector3D(pybind11::list tpl) {
+    return tupleToVector<double, 3>(tpl);
+}
+
 inline Vector4D tupleToVector4D(pybind11::tuple tpl) {
+    return tupleToVector<double, 4>(tpl);
+}
+
+inline Vector4D tupleToVector4D(pybind11::list tpl) {
     return tupleToVector<double, 4>(tpl);
 }
 
@@ -156,6 +262,10 @@ inline QuaternionD tupleToQuaternionD(pybind11::tuple tpl) {
     return tupleToQuaternion<double>(tpl);
 }
 
+inline QuaternionD tupleToQuaternionD(pybind11::list tpl) {
+    return tupleToQuaternion<double>(tpl);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 inline Size2 objectToSize2(const pybind11::object& obj) {
@@ -163,6 +273,8 @@ inline Size2 objectToSize2(const pybind11::object& obj) {
         return obj.cast<Size2>();
     } else if (pybind11::isinstance<pybind11::tuple>(obj)) {
         return tupleToSize2(pybind11::tuple(obj));
+    } else if (pybind11::isinstance<pybind11::list>(obj)) {
+        return tupleToSize2(pybind11::list(obj));
     } else {
         throw std::invalid_argument("Cannot convert to Size2.");
     }
@@ -173,6 +285,8 @@ inline Size3 objectToSize3(const pybind11::object& obj) {
         return obj.cast<Size3>();
     } else if (pybind11::isinstance<pybind11::tuple>(obj)) {
         return tupleToSize3(pybind11::tuple(obj));
+    } else if (pybind11::isinstance<pybind11::list>(obj)) {
+        return tupleToSize3(pybind11::list(obj));
     } else {
         throw std::invalid_argument("Cannot convert to Size3.");
     }
@@ -185,6 +299,8 @@ inline Point2UI objectToPoint2UI(const pybind11::object& obj) {
         return obj.cast<Point2UI>();
     } else if (pybind11::isinstance<pybind11::tuple>(obj)) {
         return tupleToPoint2UI(pybind11::tuple(obj));
+    } else if (pybind11::isinstance<pybind11::list>(obj)) {
+        return tupleToPoint2UI(pybind11::list(obj));
     } else {
         throw std::invalid_argument("Cannot convert to Point2UI.");
     }
@@ -195,6 +311,8 @@ inline Point3UI objectToPoint3UI(const pybind11::object& obj) {
         return obj.cast<Point3UI>();
     } else if (pybind11::isinstance<pybind11::tuple>(obj)) {
         return tupleToPoint3UI(pybind11::tuple(obj));
+    } else if (pybind11::isinstance<pybind11::list>(obj)) {
+        return tupleToPoint3UI(pybind11::list(obj));
     } else {
         throw std::invalid_argument("Cannot convert to Point3UI.");
     }
@@ -207,6 +325,8 @@ inline Vector2F objectToVector2F(const pybind11::object& obj) {
         return obj.cast<Vector2F>();
     } else if (pybind11::isinstance<pybind11::tuple>(obj)) {
         return tupleToVector2F(pybind11::tuple(obj));
+    } else if (pybind11::isinstance<pybind11::list>(obj)) {
+        return tupleToVector2F(pybind11::list(obj));
     } else {
         throw std::invalid_argument("Cannot convert to Vector2F.");
     }
@@ -217,6 +337,8 @@ inline Vector2D objectToVector2D(const pybind11::object& obj) {
         return obj.cast<Vector2D>();
     } else if (pybind11::isinstance<pybind11::tuple>(obj)) {
         return tupleToVector2D(pybind11::tuple(obj));
+    } else if (pybind11::isinstance<pybind11::list>(obj)) {
+        return tupleToVector2D(pybind11::list(obj));
     } else {
         throw std::invalid_argument("Cannot convert to Vector2D.");
     }
@@ -227,6 +349,8 @@ inline Vector3F objectToVector3F(const pybind11::object& obj) {
         return obj.cast<Vector3F>();
     } else if (pybind11::isinstance<pybind11::tuple>(obj)) {
         return tupleToVector3F(pybind11::tuple(obj));
+    } else if (pybind11::isinstance<pybind11::list>(obj)) {
+        return tupleToVector3F(pybind11::list(obj));
     } else {
         throw std::invalid_argument("Cannot convert to Vector3F.");
     }
@@ -237,6 +361,8 @@ inline Vector3D objectToVector3D(const pybind11::object& obj) {
         return obj.cast<Vector3D>();
     } else if (pybind11::isinstance<pybind11::tuple>(obj)) {
         return tupleToVector3D(pybind11::tuple(obj));
+    } else if (pybind11::isinstance<pybind11::list>(obj)) {
+        return tupleToVector3D(pybind11::list(obj));
     } else {
         throw std::invalid_argument("Cannot convert to Vector3D.");
     }
@@ -247,6 +373,8 @@ inline Vector4F objectToVector4F(const pybind11::object& obj) {
         return obj.cast<Vector4F>();
     } else if (pybind11::isinstance<pybind11::tuple>(obj)) {
         return tupleToVector4F(pybind11::tuple(obj));
+    } else if (pybind11::isinstance<pybind11::list>(obj)) {
+        return tupleToVector4F(pybind11::list(obj));
     } else {
         throw std::invalid_argument("Cannot convert to Vector4F.");
     }
@@ -257,6 +385,8 @@ inline Vector4D objectToVector4D(const pybind11::object& obj) {
         return obj.cast<Vector4D>();
     } else if (pybind11::isinstance<pybind11::tuple>(obj)) {
         return tupleToVector4D(pybind11::tuple(obj));
+    } else if (pybind11::isinstance<pybind11::list>(obj)) {
+        return tupleToVector4D(pybind11::list(obj));
     } else {
         throw std::invalid_argument("Cannot convert to Vector4D.");
     }
@@ -267,6 +397,8 @@ inline QuaternionF objectToQuaternionF(const pybind11::object& obj) {
         return obj.cast<QuaternionF>();
     } else if (pybind11::isinstance<pybind11::tuple>(obj)) {
         return tupleToQuaternionF(pybind11::tuple(obj));
+    } else if (pybind11::isinstance<pybind11::list>(obj)) {
+        return tupleToQuaternionF(pybind11::list(obj));
     } else {
         throw std::invalid_argument("Cannot convert to QuaternionF.");
     }
@@ -277,6 +409,8 @@ inline QuaternionD objectToQuaternionD(const pybind11::object& obj) {
         return obj.cast<QuaternionD>();
     } else if (pybind11::isinstance<pybind11::tuple>(obj)) {
         return tupleToQuaternionD(pybind11::tuple(obj));
+    } else if (pybind11::isinstance<pybind11::list>(obj)) {
+        return tupleToQuaternionD(pybind11::list(obj));
     } else {
         throw std::invalid_argument("Cannot convert to QuaternionD.");
     }
@@ -351,6 +485,6 @@ inline void parseGridResizeParams(pybind11::args args, pybind11::kwargs kwargs,
         gridSpacing.set(domainSizeX / static_cast<double>(resolution.x));
     }
 }
-}
+}  // namespace jet
 
 #endif  // SRC_PYTHON_PYBIND11_UTILS_H_

--- a/src/python/sph_points_to_implicit.cpp
+++ b/src/python/sph_points_to_implicit.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "sph_points_to_implicit.h"
+#include "pybind11_utils.h"
+
+#include <jet/sph_points_to_implicit2.h>
+#include <jet/sph_points_to_implicit3.h>
+
+namespace py = pybind11;
+using namespace jet;
+
+void addSphPointsToImplicit2(pybind11::module& m) {
+    py::class_<SphPointsToImplicit2, PointsToImplicit2,
+               SphPointsToImplicit2Ptr>(m, "SphPointsToImplicit2",
+                                        R"pbdoc(
+        2-D points-to-implicit converter based on standard SPH kernel.
+
+        \see Müller, Matthias, David Charypar, and Markus Gross.
+             "Particle-based fluid simulation for interactive applications."
+             Proceedings of the 2003 ACM SIGGRAPH/Eurographics symposium on Computer
+             animation. Eurographics Association, 2003.
+        )pbdoc")
+        .def(py::init<double, double>(),
+             R"pbdoc(
+             Constructs the converter with given kernel radius and cut-off density.
+
+             Parameters
+             ----------
+             - kernelRadius : SPH kernel radius.
+             - cutOffDensity : Iso-contour value.
+             )pbdoc",
+             py::arg("kernelRadius") = 1.0, py::arg("cutOffDensity") = 0.5);
+}
+
+void addSphPointsToImplicit3(pybind11::module& m) {
+    py::class_<SphPointsToImplicit3, PointsToImplicit3,
+               SphPointsToImplicit3Ptr>(m, "SphPointsToImplicit3",
+                                        R"pbdoc(
+        3-D points-to-implicit converter based on standard SPH kernel.
+
+        \see Müller, Matthias, David Charypar, and Markus Gross.
+             "Particle-based fluid simulation for interactive applications."
+             Proceedings of the 2003 ACM SIGGRAPH/Eurographics symposium on Computer
+             animation. Eurographics Association, 2003.
+        )pbdoc")
+        .def(py::init<double, double>(),
+             R"pbdoc(
+             Constructs the converter with given kernel radius and cut-off density.
+
+             Parameters
+             ----------
+             - kernelRadius : SPH kernel radius.
+             - cutOffDensity : Iso-contour value.
+             )pbdoc",
+             py::arg("kernelRadius") = 1.0, py::arg("cutOffDensity") = 0.5);
+}

--- a/src/python/sph_points_to_implicit.h
+++ b/src/python/sph_points_to_implicit.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef SRC_PYTHON_SPH_POINTS_TO_IMPLICIT_H_
+#define SRC_PYTHON_SPH_POINTS_TO_IMPLICIT_H_
+
+#include <pybind11/pybind11.h>
+
+void addSphPointsToImplicit2(pybind11::module& m);
+void addSphPointsToImplicit3(pybind11::module& m);
+
+#endif  // SRC_PYTHON_SPH_POINTS_TO_IMPLICIT_H_

--- a/src/python/spherical_points_to_implicit.cpp
+++ b/src/python/spherical_points_to_implicit.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "spherical_points_to_implicit.h"
+#include "pybind11_utils.h"
+
+#include <jet/spherical_points_to_implicit2.h>
+#include <jet/spherical_points_to_implicit3.h>
+
+namespace py = pybind11;
+using namespace jet;
+
+void addSphericalPointsToImplicit2(pybind11::module& m) {
+    py::class_<SphericalPointsToImplicit2, PointsToImplicit2,
+               SphericalPointsToImplicit2Ptr>(m, "SphericalPointsToImplicit2",
+                                              R"pbdoc(
+        2-D points-to-implicit converter based on simple sphere model.
+        )pbdoc")
+        .def(py::init<double>(),
+             R"pbdoc(
+             Constructs the converter with given sphere radius.
+
+             Parameters
+             ----------
+             - radius : Sphere radius.
+             )pbdoc",
+             py::arg("radius") = 1.0);
+}
+
+void addSphericalPointsToImplicit3(pybind11::module& m) {
+    py::class_<SphericalPointsToImplicit3, PointsToImplicit3,
+               SphericalPointsToImplicit3Ptr>(m, "SphericalPointsToImplicit3",
+                                              R"pbdoc(
+        3-D points-to-implicit converter based on simple sphere model.
+        )pbdoc")
+        .def(py::init<double>(),
+             R"pbdoc(
+             Constructs the converter with given sphere radius.
+
+             Parameters
+             ----------
+             - radius : Sphere radius.
+             )pbdoc",
+             py::arg("radius") = 1.0);
+}

--- a/src/python/spherical_points_to_implicit.h
+++ b/src/python/spherical_points_to_implicit.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef SRC_PYTHON_SPHERICAL_POINTS_TO_IMPLICIT_H_
+#define SRC_PYTHON_SPHERICAL_POINTS_TO_IMPLICIT_H_
+
+#include <pybind11/pybind11.h>
+
+void addSphericalPointsToImplicit2(pybind11::module& m);
+void addSphericalPointsToImplicit3(pybind11::module& m);
+
+#endif  // SRC_PYTHON_SPHERICAL_POINTS_TO_IMPLICIT_H_

--- a/src/python/zhu_bridson_points_to_implicit.cpp
+++ b/src/python/zhu_bridson_points_to_implicit.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "zhu_bridson_points_to_implicit.h"
+#include "pybind11_utils.h"
+
+#include <jet/zhu_bridson_points_to_implicit2.h>
+#include <jet/zhu_bridson_points_to_implicit3.h>
+
+namespace py = pybind11;
+using namespace jet;
+
+void addZhuBridsonPointsToImplicit2(pybind11::module& m) {
+    py::class_<ZhuBridsonPointsToImplicit2, PointsToImplicit2,
+               ZhuBridsonPointsToImplicit2Ptr>(m, "ZhuBridsonPointsToImplicit2",
+                                               R"pbdoc(
+        2-D points-to-implicit converter based on Zhu and Bridson's method.
+
+        \see Zhu, Yongning, and Robert Bridson. "Animating sand as a fluid."
+             ACM Transactions on Graphics (TOG). Vol. 24. No. 3. ACM, 2005.
+        )pbdoc")
+        .def(py::init<double, double>(),
+             R"pbdoc(
+             Constructs the converter with given kernel radius and cut-off threshold.
+
+             Parameters
+             ----------
+             - kernelRadius : Smoothing kernel radius.
+             - cutOffThreshold : Iso-contour value.
+             )pbdoc",
+             py::arg("kernelRadius") = 1.0, py::arg("cutOffThreshold") = 0.25);
+}
+
+void addZhuBridsonPointsToImplicit3(pybind11::module& m) {
+    py::class_<ZhuBridsonPointsToImplicit3, PointsToImplicit3,
+               ZhuBridsonPointsToImplicit3Ptr>(m, "ZhuBridsonPointsToImplicit3",
+                                               R"pbdoc(
+        3-D points-to-implicit converter based on Zhu and Bridson's method.
+
+        \see Zhu, Yongning, and Robert Bridson. "Animating sand as a fluid."
+             ACM Transactions on Graphics (TOG). Vol. 24. No. 3. ACM, 2005.
+        )pbdoc")
+        .def(py::init<double, double>(),
+             R"pbdoc(
+             Constructs the converter with given kernel radius and cut-off threshold.
+
+             Parameters
+             ----------
+             - kernelRadius : Smoothing kernel radius.
+             - cutOffThreshold : Iso-contour value.
+             )pbdoc",
+             py::arg("kernelRadius") = 1.0, py::arg("cutOffThreshold") = 0.25);
+}

--- a/src/python/zhu_bridson_points_to_implicit.h
+++ b/src/python/zhu_bridson_points_to_implicit.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef SRC_PYTHON_ZHU_BRIDSON_POINTS_TO_IMPLICIT_H_
+#define SRC_PYTHON_ZHU_BRIDSON_POINTS_TO_IMPLICIT_H_
+
+#include <pybind11/pybind11.h>
+
+void addZhuBridsonPointsToImplicit2(pybind11::module& m);
+void addZhuBridsonPointsToImplicit3(pybind11::module& m);
+
+#endif  // SRC_PYTHON_ZHU_BRIDSON_POINTS_TO_IMPLICIT_H_

--- a/src/tests/manual_tests/anisotropic_points_to_implicit2_tests.cpp
+++ b/src/tests/manual_tests/anisotropic_points_to_implicit2_tests.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <manual_tests.h>
+
+#include <jet/anisotropic_points_to_implicit2.h>
+#include <jet/cell_centered_scalar_grid2.h>
+
+#include <random>
+
+using namespace jet;
+
+JET_TESTS(AnisotropicPointsToImplicit2);
+
+JET_BEGIN_TEST_F(AnisotropicPointsToImplicit2, ConvertTwo) {
+    Array1<Vector2D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 2; ++i) {
+        points.append({dist(rng), dist(rng)});
+    }
+
+    CellCenteredScalarGrid2 grid(512, 512, 1.0 / 512, 1.0 / 512);
+
+    AnisotropicPointsToImplicit2 converter(0.1);
+    converter.convert(points.constAccessor(), &grid);
+
+    saveData(grid.constDataAccessor(), "data_#grid2.npy");
+    saveData(grid.constDataAccessor(), "data_#grid2,iso.npy");
+}
+JET_END_TEST_F
+
+JET_BEGIN_TEST_F(AnisotropicPointsToImplicit2, ConvertMany) {
+    Array1<Vector2D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 200; ++i) {
+        points.append({dist(rng), dist(rng)});
+    }
+
+    CellCenteredScalarGrid2 grid(512, 512, 1.0 / 512, 1.0 / 512);
+
+    AnisotropicPointsToImplicit2 converter(0.1);
+    converter.convert(points.constAccessor(), &grid);
+
+    saveData(grid.constDataAccessor(), "data_#grid2.npy");
+    saveData(grid.constDataAccessor(), "data_#grid2,iso.npy");
+}
+JET_END_TEST_F

--- a/src/tests/manual_tests/anisotropic_points_to_implicit3_tests.cpp
+++ b/src/tests/manual_tests/anisotropic_points_to_implicit3_tests.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <manual_tests.h>
+
+#include <jet/anisotropic_points_to_implicit3.h>
+#include <jet/marching_cubes.h>
+#include <jet/vertex_centered_scalar_grid3.h>
+
+#include <random>
+
+using namespace jet;
+
+JET_TESTS(AnisotropicPointsToImplicit3);
+
+JET_BEGIN_TEST_F(AnisotropicPointsToImplicit3, ConvertTwo) {
+    Array1<Vector3D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 2; ++i) {
+        points.append({dist(rng), dist(rng), dist(rng)});
+    }
+
+    VertexCenteredScalarGrid3 grid(128, 128, 128, 1.0 / 128, 1.0 / 128,
+                                   1.0 / 128);
+
+    AnisotropicPointsToImplicit3 converter(0.3);
+    converter.convert(points.constAccessor(), &grid);
+
+    TriangleMesh3 triMesh;
+    marchingCubes(grid.constDataAccessor(), grid.gridSpacing(),
+                  grid.dataOrigin(), &triMesh, 0, kDirectionAll);
+
+    saveTriangleMeshData(triMesh,
+                         "anisotropic_points_to_implicit3_convert_two.obj");
+}
+JET_END_TEST_F
+
+JET_BEGIN_TEST_F(AnisotropicPointsToImplicit3, ConvertMany) {
+    Array1<Vector3D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 500; ++i) {
+        points.append({dist(rng), dist(rng), dist(rng)});
+    }
+
+    VertexCenteredScalarGrid3 grid(128, 128, 128, 1.0 / 128, 1.0 / 128,
+                                   1.0 / 128);
+
+    AnisotropicPointsToImplicit3 converter(0.1);
+    converter.convert(points.constAccessor(), &grid);
+
+    TriangleMesh3 triMesh;
+    marchingCubes(grid.constDataAccessor(), grid.gridSpacing(),
+                  grid.dataOrigin(), &triMesh, 0, kDirectionAll);
+
+    saveTriangleMeshData(triMesh,
+                         "anisotropic_points_to_implicit3_convert_many.obj");
+}
+JET_END_TEST_F

--- a/src/tests/manual_tests/sph_points_to_implicit2_tests.cpp
+++ b/src/tests/manual_tests/sph_points_to_implicit2_tests.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <manual_tests.h>
+
+#include <jet/cell_centered_scalar_grid2.h>
+#include <jet/sph_points_to_implicit2.h>
+
+#include <random>
+
+using namespace jet;
+
+JET_TESTS(SphPointsToImplicit2);
+
+JET_BEGIN_TEST_F(SphPointsToImplicit2, ConvertTwo) {
+    Array1<Vector2D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 2; ++i) {
+        points.append({dist(rng), dist(rng)});
+    }
+
+    CellCenteredScalarGrid2 grid(512, 512, 1.0 / 512, 1.0 / 512);
+
+    SphPointsToImplicit2 converter(0.1);
+    converter.convert(points.constAccessor(), &grid);
+
+    saveData(grid.constDataAccessor(), "data_#grid2.npy");
+    saveData(grid.constDataAccessor(), "data_#grid2,iso.npy");
+}
+JET_END_TEST_F
+
+JET_BEGIN_TEST_F(SphPointsToImplicit2, ConvertMany) {
+    Array1<Vector2D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 200; ++i) {
+        points.append({dist(rng), dist(rng)});
+    }
+
+    CellCenteredScalarGrid2 grid(512, 512, 1.0 / 512, 1.0 / 512);
+
+    SphPointsToImplicit2 converter(0.1);
+    converter.convert(points.constAccessor(), &grid);
+
+    saveData(grid.constDataAccessor(), "data_#grid2.npy");
+    saveData(grid.constDataAccessor(), "data_#grid2,iso.npy");
+}
+JET_END_TEST_F

--- a/src/tests/manual_tests/sph_points_to_implicit3_tests.cpp
+++ b/src/tests/manual_tests/sph_points_to_implicit3_tests.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <manual_tests.h>
+
+#include <jet/marching_cubes.h>
+#include <jet/sph_points_to_implicit3.h>
+#include <jet/vertex_centered_scalar_grid3.h>
+
+#include <random>
+
+using namespace jet;
+
+JET_TESTS(SphPointsToImplicit3);
+
+JET_BEGIN_TEST_F(SphPointsToImplicit3, ConvertTwo) {
+    Array1<Vector3D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 2; ++i) {
+        points.append({dist(rng), dist(rng), dist(rng)});
+    }
+
+    VertexCenteredScalarGrid3 grid(128, 128, 128, 1.0 / 128, 1.0 / 128,
+                                   1.0 / 128);
+
+    SphPointsToImplicit3 converter(0.3);
+    converter.convert(points.constAccessor(), &grid);
+
+    TriangleMesh3 triMesh;
+    marchingCubes(grid.constDataAccessor(), grid.gridSpacing(),
+                  grid.dataOrigin(), &triMesh, 0, kDirectionAll);
+
+    saveTriangleMeshData(triMesh, "sph_points_to_implicit3_convert_two.obj");
+}
+JET_END_TEST_F
+
+JET_BEGIN_TEST_F(SphPointsToImplicit3, ConvertMany) {
+    Array1<Vector3D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 500; ++i) {
+        points.append({dist(rng), dist(rng), dist(rng)});
+    }
+
+    VertexCenteredScalarGrid3 grid(128, 128, 128, 1.0 / 128, 1.0 / 128,
+                                   1.0 / 128);
+
+    SphPointsToImplicit3 converter(0.1);
+    converter.convert(points.constAccessor(), &grid);
+
+    TriangleMesh3 triMesh;
+    marchingCubes(grid.constDataAccessor(), grid.gridSpacing(),
+                  grid.dataOrigin(), &triMesh, 0, kDirectionAll);
+
+    saveTriangleMeshData(triMesh, "sph_points_to_implicit3_convert_many.obj");
+}
+JET_END_TEST_F

--- a/src/tests/manual_tests/spherical_points_to_implicit2_tests.cpp
+++ b/src/tests/manual_tests/spherical_points_to_implicit2_tests.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <manual_tests.h>
+
+#include <jet/cell_centered_scalar_grid2.h>
+#include <jet/spherical_points_to_implicit2.h>
+
+#include <random>
+
+using namespace jet;
+
+JET_TESTS(SphericalPointsToImplicit2);
+
+JET_BEGIN_TEST_F(SphericalPointsToImplicit2, ConvertTwo) {
+    Array1<Vector2D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 2; ++i) {
+        points.append({dist(rng), dist(rng)});
+    }
+
+    CellCenteredScalarGrid2 grid(512, 512, 1.0 / 512, 1.0 / 512);
+
+    SphericalPointsToImplicit2 converter(0.1);
+    converter.convert(points.constAccessor(), &grid);
+
+    saveData(grid.constDataAccessor(), "data_#grid2.npy");
+    saveData(grid.constDataAccessor(), "data_#grid2,iso.npy");
+}
+JET_END_TEST_F
+
+JET_BEGIN_TEST_F(SphericalPointsToImplicit2, ConvertMany) {
+    Array1<Vector2D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 200; ++i) {
+        points.append({dist(rng), dist(rng)});
+    }
+
+    CellCenteredScalarGrid2 grid(512, 512, 1.0 / 512, 1.0 / 512);
+
+    SphericalPointsToImplicit2 converter(0.1);
+    converter.convert(points.constAccessor(), &grid);
+
+    saveData(grid.constDataAccessor(), "data_#grid2.npy");
+    saveData(grid.constDataAccessor(), "data_#grid2,iso.npy");
+}
+JET_END_TEST_F

--- a/src/tests/manual_tests/spherical_points_to_implicit3_tests.cpp
+++ b/src/tests/manual_tests/spherical_points_to_implicit3_tests.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <manual_tests.h>
+
+#include <jet/marching_cubes.h>
+#include <jet/spherical_points_to_implicit3.h>
+#include <jet/vertex_centered_scalar_grid3.h>
+
+#include <random>
+
+using namespace jet;
+
+JET_TESTS(SphericalPointsToImplicit3);
+
+JET_BEGIN_TEST_F(SphericalPointsToImplicit3, ConvertTwo) {
+    Array1<Vector3D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 2; ++i) {
+        points.append({dist(rng), dist(rng), dist(rng)});
+    }
+
+    VertexCenteredScalarGrid3 grid(128, 128, 128, 1.0 / 128, 1.0 / 128,
+                                   1.0 / 128);
+
+    SphericalPointsToImplicit3 converter(0.15);
+    converter.convert(points.constAccessor(), &grid);
+
+    TriangleMesh3 triMesh;
+    marchingCubes(grid.constDataAccessor(), grid.gridSpacing(),
+                  grid.dataOrigin(), &triMesh, 0, kDirectionAll);
+
+    saveTriangleMeshData(triMesh,
+                         "spherical_points_to_implicit3_convert_two.obj");
+}
+JET_END_TEST_F
+
+JET_BEGIN_TEST_F(SphericalPointsToImplicit3, ConvertMany) {
+    Array1<Vector3D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 500; ++i) {
+        points.append({dist(rng), dist(rng), dist(rng)});
+    }
+
+    VertexCenteredScalarGrid3 grid(128, 128, 128, 1.0 / 128, 1.0 / 128,
+                                   1.0 / 128);
+
+    SphericalPointsToImplicit3 converter(0.1);
+    converter.convert(points.constAccessor(), &grid);
+
+    TriangleMesh3 triMesh;
+    marchingCubes(grid.constDataAccessor(), grid.gridSpacing(),
+                  grid.dataOrigin(), &triMesh, 0, kDirectionAll);
+
+    saveTriangleMeshData(triMesh,
+                         "spherical_points_to_implicit3_convert_many.obj");
+}
+JET_END_TEST_F

--- a/src/tests/manual_tests/zhu_bridson_points_to_implicit2_tests.cpp
+++ b/src/tests/manual_tests/zhu_bridson_points_to_implicit2_tests.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <manual_tests.h>
+
+#include <jet/cell_centered_scalar_grid2.h>
+#include <jet/zhu_bridson_points_to_implicit2.h>
+
+#include <random>
+
+using namespace jet;
+
+JET_TESTS(ZhuBridsonPointsToImplicit2);
+
+JET_BEGIN_TEST_F(ZhuBridsonPointsToImplicit2, ConvertTwo) {
+    Array1<Vector2D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 2; ++i) {
+        points.append({dist(rng), dist(rng)});
+    }
+
+    CellCenteredScalarGrid2 grid(512, 512, 1.0 / 512, 1.0 / 512);
+
+    ZhuBridsonPointsToImplicit2 converter(0.1);
+    converter.convert(points.constAccessor(), &grid);
+
+    saveData(grid.constDataAccessor(), "data_#grid2.npy");
+    saveData(grid.constDataAccessor(), "data_#grid2,iso.npy");
+}
+JET_END_TEST_F
+
+JET_BEGIN_TEST_F(ZhuBridsonPointsToImplicit2, ConvertMany) {
+    Array1<Vector2D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 200; ++i) {
+        points.append({dist(rng), dist(rng)});
+    }
+
+    CellCenteredScalarGrid2 grid(512, 512, 1.0 / 512, 1.0 / 512);
+
+    ZhuBridsonPointsToImplicit2 converter(0.1);
+    converter.convert(points.constAccessor(), &grid);
+
+    saveData(grid.constDataAccessor(), "data_#grid2.npy");
+    saveData(grid.constDataAccessor(), "data_#grid2,iso.npy");
+}
+JET_END_TEST_F

--- a/src/tests/manual_tests/zhu_bridson_points_to_implicit3_tests.cpp
+++ b/src/tests/manual_tests/zhu_bridson_points_to_implicit3_tests.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <manual_tests.h>
+
+#include <jet/marching_cubes.h>
+#include <jet/vertex_centered_scalar_grid3.h>
+#include <jet/zhu_bridson_points_to_implicit3.h>
+
+#include <random>
+
+using namespace jet;
+
+JET_TESTS(ZhuBridsonPointsToImplicit3);
+
+JET_BEGIN_TEST_F(ZhuBridsonPointsToImplicit3, ConvertTwo) {
+    Array1<Vector3D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 2; ++i) {
+        points.append({dist(rng), dist(rng), dist(rng)});
+    }
+
+    VertexCenteredScalarGrid3 grid(128, 128, 128, 1.0 / 128, 1.0 / 128,
+                                   1.0 / 128);
+
+    ZhuBridsonPointsToImplicit3 converter(0.6, 0.25);
+    converter.convert(points.constAccessor(), &grid);
+
+    TriangleMesh3 triMesh;
+    marchingCubes(grid.constDataAccessor(), grid.gridSpacing(),
+                  grid.dataOrigin(), &triMesh, 0, kDirectionAll);
+
+    saveTriangleMeshData(triMesh,
+                         "zhu_bridson_points_to_implicit3_convert_two.obj");
+}
+JET_END_TEST_F
+
+JET_BEGIN_TEST_F(ZhuBridsonPointsToImplicit3, ConvertMany) {
+    Array1<Vector3D> points;
+
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist(0.2, 0.8);
+    for (size_t i = 0; i < 500; ++i) {
+        points.append({dist(rng), dist(rng), dist(rng)});
+    }
+
+    VertexCenteredScalarGrid3 grid(128, 128, 128, 1.0 / 128, 1.0 / 128,
+                                   1.0 / 128);
+
+    ZhuBridsonPointsToImplicit3 converter(0.2, 0.25);
+    converter.convert(points.constAccessor(), &grid);
+
+    TriangleMesh3 triMesh;
+    marchingCubes(grid.constDataAccessor(), grid.gridSpacing(),
+                  grid.dataOrigin(), &triMesh, 0, kDirectionAll);
+
+    saveTriangleMeshData(triMesh,
+                         "zhu_bridson_points_to_implicit3_convert_many.obj");
+}
+JET_END_TEST_F

--- a/src/tests/python_tests/bounding_box_tests.py
+++ b/src/tests/python_tests/bounding_box_tests.py
@@ -10,6 +10,77 @@ import pyjet
 import unittest
 
 
+class BoundingBox2FTests(unittest.TestCase):
+    def testInit(self):
+        a = pyjet.BoundingBox2F()
+        self.assertGreater(a.lowerCorner.x, a.upperCorner.x)
+        self.assertGreater(a.lowerCorner.y, a.upperCorner.y)
+        b = pyjet.BoundingBox2F((-1, -2), (4, 2))
+        self.assertEqual(b.lowerCorner.x, -1.0)
+        self.assertEqual(b.lowerCorner.y, -2.0)
+        self.assertEqual(b.upperCorner.x, 4.0)
+        self.assertEqual(b.upperCorner.y, 2.0)
+        l, c = pyjet.Vector2F(-1, -2), pyjet.Vector2F(4, 2)
+        c = pyjet.BoundingBox2F(l, c)
+        self.assertEqual(c.lowerCorner.x, -1.0)
+        self.assertEqual(c.lowerCorner.y, -2.0)
+        self.assertEqual(c.upperCorner.x, 4.0)
+        self.assertEqual(c.upperCorner.y, 2.0)
+
+    def testIsEmpty(self):
+        a = pyjet.BoundingBox2F((-2.0, -2.0), (4.0, 3.0))
+        self.assertFalse(a.isEmpty())
+
+
+class BoundingBox2DTests(unittest.TestCase):
+    def testInit(self):
+        a = pyjet.BoundingBox2D()
+        self.assertGreater(a.lowerCorner.x, a.upperCorner.x)
+        self.assertGreater(a.lowerCorner.y, a.upperCorner.y)
+        b = pyjet.BoundingBox2D((-1, -2), (4, 2))
+        self.assertEqual(b.lowerCorner.x, -1.0)
+        self.assertEqual(b.lowerCorner.y, -2.0)
+        self.assertEqual(b.upperCorner.x, 4.0)
+        self.assertEqual(b.upperCorner.y, 2.0)
+        l, u = pyjet.Vector2D(-1, -2), pyjet.Vector2D(4, 2)
+        c = pyjet.BoundingBox2D(l, u)
+        self.assertEqual(c.lowerCorner.x, -1.0)
+        self.assertEqual(c.lowerCorner.y, -2.0)
+        self.assertEqual(c.upperCorner.x, 4.0)
+        self.assertEqual(c.upperCorner.y, 2.0)
+
+    def testIsEmpty(self):
+        a = pyjet.BoundingBox2D((-2.0, -2.0), (4.0, 3.0))
+        self.assertFalse(a.isEmpty())
+
+
+class BoundingBox3FTests(unittest.TestCase):
+    def testInit(self):
+        a = pyjet.BoundingBox3F()
+        self.assertGreater(a.lowerCorner.x, a.upperCorner.x)
+        self.assertGreater(a.lowerCorner.y, a.upperCorner.y)
+        self.assertGreater(a.lowerCorner.z, a.upperCorner.z)
+        b = pyjet.BoundingBox3F((-1, -2, -3), (4, 2, 5))
+        self.assertEqual(b.lowerCorner.x, -1.0)
+        self.assertEqual(b.lowerCorner.y, -2.0)
+        self.assertEqual(b.lowerCorner.z, -3.0)
+        self.assertEqual(b.upperCorner.x, 4.0)
+        self.assertEqual(b.upperCorner.y, 2.0)
+        self.assertEqual(b.upperCorner.z, 5.0)
+        l, c = pyjet.Vector3F(-1, -2, -3), pyjet.Vector3F(4, 2, 5)
+        c = pyjet.BoundingBox3F(l, c)
+        self.assertEqual(c.lowerCorner.x, -1.0)
+        self.assertEqual(c.lowerCorner.y, -2.0)
+        self.assertEqual(c.lowerCorner.z, -3.0)
+        self.assertEqual(c.upperCorner.x, 4.0)
+        self.assertEqual(c.upperCorner.y, 2.0)
+        self.assertEqual(c.upperCorner.z, 5.0)
+
+    def testIsEmpty(self):
+        a = pyjet.BoundingBox3F((-2.0, -2.0, 1.0), (4.0, 3.0, 5.0))
+        self.assertFalse(a.isEmpty())
+
+
 class BoundingBox3DTests(unittest.TestCase):
     def testInit(self):
         a = pyjet.BoundingBox3D()
@@ -31,6 +102,10 @@ class BoundingBox3DTests(unittest.TestCase):
         self.assertEqual(c.upperCorner.x, 4.0)
         self.assertEqual(c.upperCorner.y, 2.0)
         self.assertEqual(c.upperCorner.z, 5.0)
+
+    def testIsEmpty(self):
+        a = pyjet.BoundingBox3D((-2.0, -2.0, 1.0), (4.0, 3.0, 5.0))
+        self.assertFalse(a.isEmpty())
 
 
 def main():

--- a/src/tests/python_tests/main.py
+++ b/src/tests/python_tests/main.py
@@ -14,6 +14,7 @@ from face_centered_grid_tests import *
 from flip_solver_tests import *
 from particle_system_data_tests import *
 from physics_animation_tests import *
+from sph_system_data_tests import *
 from sphere_tests import *
 from vector_tests import *
 from quaternion_tests import *

--- a/src/tests/python_tests/sph_system_data_tests.py
+++ b/src/tests/python_tests/sph_system_data_tests.py
@@ -1,0 +1,47 @@
+"""
+Copyright (c) 2017 Doyub Kim
+
+I am making my contributions/submissions to this project solely in my personal
+capacity and am not conveying any rights to any intellectual property of any
+third parties.
+"""
+
+import pyjet
+import unittest
+
+
+class SphSystemData2Tests(unittest.TestCase):
+    def testParameters(self):
+        data = pyjet.SphSystemData2()
+
+        data.targetDensity = 123.0
+        data.targetSpacing = 0.549
+        data.relativeKernelRadius = 2.5
+
+        self.assertEqual(data.targetDensity, 123.0)
+        self.assertEqual(data.targetSpacing, 0.549)
+        self.assertEqual(data.radius, 0.549)
+        self.assertEqual(data.relativeKernelRadius, 2.5)
+        self.assertEqual(data.kernelRadius, 2.5 * 0.549)
+
+        data.kernelRadius = 1.9
+        self.assertEqual(data.kernelRadius, 1.9)
+        self.assertEqual(data.targetSpacing, 1.9 / 2.5)
+
+        data.radius = 0.413
+        self.assertEqual(data.targetSpacing, 0.413)
+        self.assertEqual(data.radius, 0.413)
+        self.assertEqual(data.relativeKernelRadius, 2.5)
+        self.assertEqual(data.kernelRadius, 2.5 * 0.413)
+
+        data.mass = 2.0 * data.mass
+        self.assertEqual(data.targetDensity, 246.0)
+
+
+def main():
+    pyjet.Logging.mute()
+    unittest.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/tests/unit_tests/bounding_box2_tests.cpp
+++ b/src/tests/unit_tests/bounding_box2_tests.cpp
@@ -215,3 +215,17 @@ TEST(BoundingBox2, Corner) {
     EXPECT_VECTOR2_EQ(Vector2D(-2.0, 3.0), box.corner(2));
     EXPECT_VECTOR2_EQ(Vector2D(4.0, 3.0), box.corner(3));
 }
+
+TEST(BoundingBox2D, IsEmpty) {
+    BoundingBox2D box(Vector2D(-2.0, -2.0), Vector2D(4.0, 3.0));
+    EXPECT_FALSE(box.isEmpty());
+
+    box.lowerCorner = Vector2D(5.0, 1.0);
+    EXPECT_TRUE(box.isEmpty());
+
+    box.lowerCorner = Vector2D(2.0, 4.0);
+    EXPECT_TRUE(box.isEmpty());
+
+    box.lowerCorner = Vector2D(4.0, 1.0);
+    EXPECT_TRUE(box.isEmpty());
+}

--- a/src/tests/unit_tests/bounding_box3_tests.cpp
+++ b/src/tests/unit_tests/bounding_box3_tests.cpp
@@ -253,3 +253,20 @@ TEST(BoundingBox3, Corner) {
     EXPECT_VECTOR3_EQ(Vector3D(-2.0, 3.0, 5.0), box.corner(6));
     EXPECT_VECTOR3_EQ(Vector3D(4.0, 3.0, 5.0), box.corner(7));
 }
+
+TEST(BoundingBox3D, IsEmpty) {
+    BoundingBox3D box(Vector3D(-2.0, -2.0, 1.0), Vector3D(4.0, 3.0, 5.0));
+    EXPECT_FALSE(box.isEmpty());
+
+    box.lowerCorner = Vector3D(5.0, 1.0, 3.0);
+    EXPECT_TRUE(box.isEmpty());
+
+    box.lowerCorner = Vector3D(2.0, 4.0, 3.0);
+    EXPECT_TRUE(box.isEmpty());
+
+    box.lowerCorner = Vector3D(2.0, 1.0, 6.0);
+    EXPECT_TRUE(box.isEmpty());
+
+    box.lowerCorner = Vector3D(4.0, 1.0, 3.0);
+    EXPECT_TRUE(box.isEmpty());
+}

--- a/src/tests/unit_tests/svd_tests.cpp
+++ b/src/tests/unit_tests/svd_tests.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <jet/svd.h>
+
+#include <gtest/gtest.h>
+
+using namespace jet;
+
+TEST(Svd, Float) {
+    MatrixMxNF a{{0, 1}, {1, 1}, {1, 0}};
+
+    MatrixMxNF u, v;
+    VectorNF w;
+
+    svd(a, u, w, v);
+
+    MatrixMxNF w2(2, 2);
+    w2(0, 0) = w[0];
+    w2(1, 1) = w[1];
+
+    MatrixMxNF aApprox = u * w2 * v.transposed();
+    EXPECT_TRUE(a.isSimilar(aApprox, 1e-6));
+}
+
+TEST(Svd, Double) {
+    MatrixMxND a{{0, 1}, {1, 1}, {1, 0}};
+
+    MatrixMxND u, v;
+    VectorND w;
+
+    svd(a, u, w, v);
+
+    MatrixMxND w2(2, 2);
+    w2(0, 0) = w[0];
+    w2(1, 1) = w[1];
+
+    MatrixMxND aApprox = u * w2 * v.transposed();
+    EXPECT_TRUE(a.isSimilar(aApprox, 1e-12));
+}


### PR DESCRIPTION
This revision includes four different kinds of surface reconstruction algorithms of points such as:
* Spherical representation (union of spheres)
* SPH blobby (metaball-like) [Müller et al., 2003]
* Zhu and Bridson's method [Zhu and Bridson, 2005]
* Anisotropic kernel [Yu and Turk, 2010]